### PR TITLE
Fix web links

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,10 +1,11 @@
 #+TITLE: DocBook xsltNG README
 
-Build status:
-[[https://circleci.com/gh/ndw/docbook-xsltNG.svg?style=svg&circle-token=fff3d12b38fab0fbce5b9f431f80d1b44f1b5553]]
+Build status: [[https://circleci.com/gh/docbook/xsltNG.svg?style=shield]]
 
 Hello. You’ve found this repository during it’s “soft opening.” It’s
 public and it should all work, but I haven’t made any announcements
 about it.
 
 It’s not a secret, but [[https://www.merriam-webster.com/dictionary/keep+(something)+under+one's+hat][keep it under your hat]], ok?
+
+P.S. The home page for the project is published at [[https://xsltng.docbook.org/]].

--- a/src/website/html/homepage.html
+++ b/src/website/html/homepage.html
@@ -165,7 +165,7 @@ published <?pubdate?>.</p>
 since the last release.</p>
 
 <p>Current build status:
-<img src="https://circleci.com/gh/ndw/docbook-xsltNG.svg?style=svg&amp;circle-token=fff3d12b38fab0fbce5b9f431f80d1b44f1b5553"/>; <?testsummary?>
+<img src="https://circleci.com/gh/docbook/xsltNG.svg?style=shield"/>; <?testsummary?>
 </p>
 
 <p>Instructions for building the stylesheets from the sources are


### PR DESCRIPTION
Fix the badge links so they point at the DocBook repo and not my private one.

Added pointer to xsltng.docbook.org to the README.

This will also test pull requests.