### PR TITLE
Avoid .replaceAll()

### DIFF
--- a/src/main/web/js/annotations.js
+++ b/src/main/web/js/annotations.js
@@ -89,7 +89,7 @@
   document.querySelectorAll("a.annomark").forEach(function(mark) {
     let id = mark.getAttribute("href");
     // Escape characters that confuse querySelector
-    id = id.replaceAll(".", "\\.");
+    id = id.replace(/\./g, "\\.");
     mark.onclick = function (event) {
       showAnnotation(event, id);
     };
@@ -105,7 +105,7 @@
     let id = anno.getAttribute("id");
     if (id) {
       // Escape characters that confuse querySelector
-      id = id.replaceAll(".", "\\.");
+      id = id.replace(/\./g, "\\.");
       anno.onclick = function (event) {
         hideAnnotation(event, `#${id}`);
       };

--- a/src/website/resources/samples/fit/js/annotations.js
+++ b/src/website/resources/samples/fit/js/annotations.js
@@ -52,7 +52,7 @@
   document.querySelectorAll("a.annomark").forEach(function(mark) {
     let id = mark.getAttribute("href");
     // Escape characters that confuse querySelector
-    id = id.replaceAll(".", "\\.");
+    id = id.replace(/\./g, "\\.");
     mark.onclick = function (event) {
       showAnnotation(event, id);
     };
@@ -62,7 +62,7 @@
     let id = anno.getAttribute("id");
     if (id) {
       // Escape characters that confuse querySelector
-      id = id.replaceAll(".", "\\.");
+      id = id.replace(/\./g, "\\.");
       anno.onclick = function (event) {
         hideAnnotation(event, `#${id}`);
       };


### PR DESCRIPTION
The `String.prototype.replaceAll` method is not as widely supported as I thought. Mea culpa.

Close #52 