### PR TITLE
Make first sections part of their parent chunk

### DIFF
--- a/src/main/xslt/param.xsl
+++ b/src/main/xslt/param.xsl
@@ -266,6 +266,8 @@
            select="('self::db:partintro',
                     'self::*[ancestor::db:partintro]',
                     'self::db:annotation',
+                    'self::db:section[not(preceding-sibling::db:section)]',
+                    'self::db:sect1[not(preceding-sibling::db:sect1)]',
                     'self::db:toc')"/>
 
 <xsl:param name="html-extension" select="'.html'"/>


### PR DESCRIPTION
Changed the default chunking rules so that the first section of a chapter, appendix, or other component is included in the chunk with that component. This will improve the presentation of components that have only a short amount of introductory material before the first section (and greatly improve the presentation when there is no introductory material before the first section).

Fix #45.
