### PR TITLE
Publish snapshot releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,69 +1,6 @@
 version: 2
 jobs:
-
-  # FIXME: Work out how to use YAML features or “Orbs” to reduce the
-  # redundancy in this configuration. The ‘testbuild’ and ‘deploybuild’
-  # jobs are essentially the same. They only differ in the gradle target.
-
-  testbuild:
-    machine:
-      image: ubuntu-1604:202004-01
-
-    working_directory: ~/repo
-
-    environment:
-      JVM_OPTS: -Xmx8g
-      TERM: dumb
-
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "cc:ad:40:0f:66:d9:d9:ae:7b:48:6e:65:9f:e6:ac:be"
-            - "8d:a0:f7:aa:e8:d5:41:7e:85:eb:10:71:49:16:33:c1"
-            - "79:a8:2b:3d:12:40:1e:45:24:41:18:30:47:81:d9:61"
-            - "c9:3f:d7:23:7a:36:05:cf:f2:ad:08:68:0b:16:57:4b"
-            - "3b:70:31:86:74:31:25:e6:18:aa:ec:1b:01:d9:2d:76"
-            - "7e:53:fb:00:34:99:b8:78:e6:3a:06:d7:7d:dd:01:b3"
-
-      - run: python3 -m pip install pygments==2.6.1 click
-
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: openssl aes-256-cbc -d -k $SAXPASSPHRASE -in tools/saxon.enc | tar zxf -
-
-      - run: ./gradlew dependencies
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
-
-      - run: ./gradlew website
-
-      - run: rm -rf lib
-
-      - persist_to_workspace:
-          root: build
-          paths:
-            - distributions
-            - website
-            - stage
-
-      - store_artifacts:
-          path: build/website
-
-      - store_artifacts:
-          path: build/stage
-
-      - run: ./.circleci/publish-website.sh
-
-  deploybuild:
+  build:
     machine:
       image: ubuntu-1604:202004-01
 
@@ -139,13 +76,13 @@ workflows:
   version: 2
   check:
     jobs:
-      - testbuild:
+      - build:
           filters:
             branches:
               ignore: gh-pages
   deploy:
     jobs:
-      - deploybuild:
+      - build:
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
               only: /.+/
       - publish-github-release:
           requires:
-            - deploybuild
+            - build
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/publish-cdn.sh
+++ b/.circleci/publish-cdn.sh
@@ -3,8 +3,11 @@
 if [[ -v CIRCLE_TAG ]]; then
     echo "Deploying CDN updates for $CIRCLE_TAG"
 else
-    echo "CDN updates are not published for untagged builds"
-    exit
+    if [ "$CIRCLE_PROJECT_USERNAME" != "docbook" \
+         -o "$CIRCLE_BRANCH" != "main" ]; then
+        echo "Snapshots are only for docbook/main commits"
+        exit
+    fi
 fi
 
 if [ `git branch -r | grep "origin/gh-pages" | wc -l` = 0 ]; then
@@ -32,16 +35,21 @@ mkdir cdn
 cd cdn
 git clone --depth 1 -c core.sshCommand="/usr/bin/ssh -i $IDRSA" git@github.com:docbook/cdn.git .
 
-# We should never be republishing to the same tag, but just in case...
-rm -rf release/xsltng/$CIRCLE_TAG
-mkdir -p release/xsltng/$CIRCLE_TAG
-rsync -ar --exclude bin --exclude libs --exclude samples --exclude docker \
-      ../repo/build/stage/zip/ release/xsltng/$CIRCLE_TAG/
+if [[ -v CIRCLE_TAG ]]; then
+    mkdir -p release/xsltng/snapshot
+    cp ../repo/build/distributions/*.zip release/xsltng/snapshot/
+else
+    # We should never be republishing to the same tag, but just in case...
+    rm -rf release/xsltng/$CIRCLE_TAG
+    mkdir -p release/xsltng/$CIRCLE_TAG
+    rsync -ar --exclude bin --exclude libs --exclude samples --exclude docker \
+          ../repo/build/stage/zip/ release/xsltng/$CIRCLE_TAG/
 
-# Make this the current release too
-rm -rf release/xsltng/current
-mkdir -p release/xsltng/current
-rsync -ar release/xsltng/$CIRCLE_TAG/ release/xsltng/current/
+    # Make this the current release too
+    rm -rf release/xsltng/current
+    mkdir -p release/xsltng/current
+    rsync -ar release/xsltng/$CIRCLE_TAG/ release/xsltng/current/
+fi
 
 # generate indexes
 perl bin/make-indexes.pl release/xsltng

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,13 @@ if (!hasProperty("sonatypePassword")) {
   ext.sonatypePassword=""
 }
 
+// If this is running on the CI infrastructure and it's not
+// a tagged build, add -SNAPSHOT to the version.
+if (System.getenv()["CIRCLECI"] == "true"
+    && System.getenv()["CIRCLE_TAG"] == null) {
+  xslTNGversion = xslTNGversion + "-SNAPSHOT"
+}
+
 // These are the top-level XSpec test drivers
 def testDrivers = ['docbook.xspec', 'main.xspec', '00_logstruct.xspec',
                    '20_db4to5.xspec', 'local_conventions.xspec']
@@ -1828,6 +1835,7 @@ task xsltest(type: Exec) {
 
 task helloWorld() {
   doLast {
-    println('Hello, world: ' + pygmentize)
+    println('Hello, world: ' + xslTNGversion)
+    println("Tag: " + System.getenv()["CIRCLE_TAG"])
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ verbose=false
 
 xslTNGtitle=DocBook xslTNG
 xslTNGbaseName=docbook-xslTNG
-xslTNGversion=1.2.0
-guideVersion=1.2.0
+xslTNGversion=1.3.0a1
+guideVersion=1.3.0a1
 
 saxonVersion=10.1
 saxonEE=true


### PR DESCRIPTION
This PR enables snapshot releases to be published. Commits that are merged into `docbook/main` will be pushed to the DocBook CDN in the `release/xsltng/snapshot` directory. To avoid confusion with tagged releases, the version number will always include `-SNAPSHOT`.