### PR TITLE
transform oXygen change PIs to DocBook in the preprocessing pipeline

### DIFF
--- a/src/main/web/css/oxy-markup.css
+++ b/src/main/web/css/oxy-markup.css
@@ -1,0 +1,16 @@
+/* @@TITLE@@ version @@VERSION@@
+ *
+ * This is speaker-notes.css. This CSS supports oXygen change markup 
+ * processing instructions, converted to DocBook proper and then to 
+ * HTML classes/spans.
+ *
+ * See https://xsltng.docbook.org/
+ *
+ */
+
+.oxy_insert {
+  color: #1a1;
+}
+.oxy_delete {
+  color: #c33;
+}

--- a/src/main/xslt/drivers.xsl
+++ b/src/main/xslt/drivers.xsl
@@ -14,6 +14,8 @@
                 exclude-result-prefixes="db ext f m map mp t v vp xs"
                 version="3.0">
 
+
+
 <xsl:template name="t:preprocess" as="document-node()">
   <xsl:param name="source" as="document-node()" select="."/>
 
@@ -153,6 +155,22 @@
     <xsl:message select="'Ignoring validation, extension unavailable'"/>
   </xsl:if>
 
+  <xsl:variable name="source" as="document-node()">
+    <xsl:choose>
+      <xsl:when test="exists($source//processing-instruction()[starts-with(name(), 'oxy_')])">
+        <xsl:message use-when="'pipeline' = $v:debug"
+                     select="'Preprocess: oxy-markup'"/>
+        <xsl:sequence select="transform(map {
+                          'stylesheet-location': 'transforms/80-oxy-markup.xsl',
+                          'source-node': $source
+                          })?output"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="$source"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  
   <xsl:sequence select="$source"/>
 </xsl:template>
 

--- a/src/main/xslt/modules/attributes.xsl
+++ b/src/main/xslt/modules/attributes.xsl
@@ -64,7 +64,8 @@
                                       ())"/>
 </xsl:template>
 
-<xsl:template match="db:listitem|db:para|db:member"
+<xsl:template match="db:listitem|db:para|db:member
+                    |db:tbody|db:thead|db:tfoot"
               mode="m:attributes" as="attribute()*">
   <xsl:variable name="attr" as="attribute()*">
     <xsl:apply-templates select="@*"/>
@@ -356,6 +357,7 @@
   </xsl:variable>
   <xsl:sequence select="f:attributes(., $attr)"/>
 </xsl:template>
+
 
 <!-- ============================================================ -->
 

--- a/src/main/xslt/modules/tablecals.xsl
+++ b/src/main/xslt/modules/tablecals.xsl
@@ -65,6 +65,7 @@
 
 <xsl:template match="db:tbody|db:thead|db:tfoot">
   <xsl:element name="{local-name(.)}" namespace="http://www.w3.org/1999/xhtml">
+    <xsl:apply-templates select="." mode="m:attributes"/>
     <xsl:apply-templates/>
   </xsl:element>
 </xsl:template>

--- a/src/main/xslt/transforms/80-oxy-markup.xsl
+++ b/src/main/xslt/transforms/80-oxy-markup.xsl
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:m="http://docbook.org/ns/docbook/modes"
+                xmlns:xlink='http://www.w3.org/1999/xlink'
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="http://docbook.org/ns/docbook"
+                default-mode="m:oxy-markup"
+                exclude-result-prefixes="db m xlink xs"
+                version="3.0">
+
+  <xsl:variable name="debug" as="xs:boolean" select="false()" static="true"/>
+
+  <xsl:template match="/">
+    <xsl:document>
+      <xsl:apply-templates/>
+    </xsl:document>
+  </xsl:template>
+
+  <!-- See https://www.oxygenxml.com/doc/versions/22.0/ug-editor/topics/track-changes-format.html -->
+
+  <xsl:mode name="m:oxy-markup" on-no-match="shallow-copy"/>
+
+  <xsl:template match="*[processing-instruction()[name() = ('oxy_comment_start', 'oxy_insert_start')]]">
+    <xsl:param name="role" as="xs:string?"/>
+    <xsl:param name="annotations" as="xs:string?"/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:if test="$role">
+        <xsl:attribute name="role" select="$role, @role" separator=" "/>
+        <xsl:attribute name="annotations" select="$annotations, @annotations" separator=" "/>
+      </xsl:if>
+      <xsl:call-template name="group-oxy">
+        <xsl:with-param name="nodes" as="node()+" select="node()"/>
+      </xsl:call-template>    
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:template name="group-oxy">
+    <xsl:param name="nodes" as="node()+"/>
+    <xsl:param name="level" select="1" as="xs:integer"/>
+    <!-- We assume start/end PIs that belong together to be siblings -->
+    <xsl:variable name="innermost" as="processing-instruction()*" 
+      select="$nodes/self::processing-instruction(oxy_comment_start)[following-sibling::processing-instruction()
+                                                                        [not(name() = ('oxy_delete', 'oxy_attributes'))][1]
+                                                                      /self::processing-instruction(oxy_comment_end)]
+              union
+              $nodes/self::processing-instruction(oxy_insert_start)[following-sibling::processing-instruction()
+                                                                        [not(name() = ('oxy_delete', 'oxy_attributes'))][1]
+                                                                     /self::processing-instruction(oxy_insert_end)]"/>
+    <xsl:choose>
+      <xsl:when test="exists($innermost)">
+        <xsl:variable name="grouped" as="document-node()">
+          <xsl:document>
+          <xsl:for-each-group select="$nodes" group-starting-with="node()[exists(. intersect $innermost)]">
+            <xsl:choose>
+              <xsl:when test="exists(
+                                  $nodes/self::processing-instruction()
+                                          [. >> current()/self::processing-instruction(oxy_comment_start)]
+                                          [not(name() = ('oxy_delete', 'oxy_attributes'))]
+                                          [1]
+                                            /self::processing-instruction(oxy_comment_end)
+                                  union
+                                  $nodes/self::processing-instruction()
+                                          [. >> current()/self::processing-instruction(oxy_insert_start)]
+                                          [not(name() = ('oxy_delete', 'oxy_attributes'))]
+                                          [1]
+                                            /self::processing-instruction(oxy_insert_end)
+                              )">
+                <xsl:variable name="end" as="processing-instruction()" 
+                  select="following-sibling::processing-instruction()[not(name() = ('oxy_delete', 'oxy_attributes'))][1]"/>
+                <xsl:choose>
+                  <xsl:when test="self::processing-instruction(oxy_insert_start)">
+                    <xsl:variable name="insert-content" as="node()*">
+                      <xsl:sequence select="current-group()[position() gt 1][. &lt;&lt; $end]"/>
+                    </xsl:variable>
+                    <xsl:apply-templates select="$insert-content">
+                      <xsl:with-param name="role" select="'oxy_insert'"/>
+                      <xsl:with-param name="annotations" select="replace(., '&quot;', '''')"/>
+                    </xsl:apply-templates>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:variable name="tmp" as="item()+">
+                      <xsl:analyze-string select="." regex="\s*comment=&quot;([^&quot;]*)&quot;">
+                        <xsl:matching-substring>
+                          <para>
+                            <xsl:sequence select="regex-group(1)"/>
+                          </para>
+                        </xsl:matching-substring>
+                        <xsl:non-matching-substring>
+                          <xsl:attribute name="annotations" select="replace(., '&quot;', '''')"/>
+                        </xsl:non-matching-substring>
+                      </xsl:analyze-string>  
+                    </xsl:variable>
+                    <annotation role="oxy_comment">
+                      <xsl:sequence select="$tmp/self::attribute(), $tmp/self::*"/>
+                    </annotation>
+                  </xsl:otherwise>
+                </xsl:choose>
+                <xsl:apply-templates select="current-group()[. >> $end]"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="current-group()"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each-group>
+          </xsl:document>
+        </xsl:variable>
+        <xsl:choose>
+          <xsl:when test="exists($grouped/processing-instruction()[name() = ('oxy_comment_start', 'oxy_insert_start')])">
+            <xsl:call-template name="group-oxy">
+              <xsl:with-param name="nodes" select="$grouped/node()"/>
+              <xsl:with-param name="level" select="$level + 1"></xsl:with-param>
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="$grouped/node()"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="$nodes"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="text()">
+    <xsl:param name="role" as="xs:string?"/>
+    <xsl:param name="annotations" as="xs:string?"/>
+    <xsl:choose>
+      <xsl:when test="$role">
+        <phrase role="{$role}" annotations="{$annotations}">
+          <xsl:sequence select="."/>
+        </phrase>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <xsl:template match="db:tgroup/text()">
+    <!-- This can only be all-whitespace text, but a user (or oXygen) managed to add insertion PIs.
+         There may be more contexts where phrase generation isn’t wanted. -->
+    <xsl:copy/>
+  </xsl:template>
+  
+  <xsl:template match="*">
+    <xsl:param name="role" as="xs:string?"/>
+    <xsl:param name="annotations" as="xs:string?"/>
+    <xsl:choose>
+      <xsl:when test="$role">
+        <xsl:copy>
+          <xsl:apply-templates select="@*"/>
+          <xsl:attribute name="role" select="$role, @role" separator=" "/>
+          <xsl:attribute name="annotations" select="$annotations, @annotations" separator=" "/>
+          <xsl:apply-templates/>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction(oxy_delete)">
+    <phrase role="oxy_delete">
+      <xsl:variable name="tmp" as="item()+">
+        <xsl:analyze-string select="." regex="\s*content=&quot;([^&quot;]*)&quot;">
+          <xsl:matching-substring>
+            <xsl:value-of select="regex-group(1)"/>
+          </xsl:matching-substring>
+          <xsl:non-matching-substring>
+            <xsl:attribute name="annotations" select="replace(., '&quot;', '''')"/>
+          </xsl:non-matching-substring>
+        </xsl:analyze-string>  
+      </xsl:variable>
+      <xsl:sequence select="$tmp/self::attribute(), $tmp/self::text()"/>
+    </phrase>
+  </xsl:template>
+  
+  <!-- We’re not dealing with oxy_attributes yet -->
+  
+  
+</xsl:stylesheet>


### PR DESCRIPTION
I don’t know whether it fits into the current pipeline or whether it’s too poorly tested yet. So feel free to reject this PR. It was just the most efficient way to let you know what I did there, and make you think whether it can be useful in the pipeline. 

The patch tries to transform matching pairs of PIs as documented [here](https://www.oxygenxml.com/doc/versions/22.0/ug-editor/topics/track-changes-format.html) into DocBook markup. Text nodes will be wrapped in a `phrase` with `@role` one of `oxy_insert` or `oxy_delete`. Elements in between will receive the corresponding (additional) role. Comments will become `annotation`s. 

It has been useful in rendering the change markup of a 600-pages long book that could not be rendered as PDF with any of the oXygen Docbook framework FOP configurations, in particular not with one that highlights changes.