### PR TITLE
Fix typo

### DIFF
--- a/src/guide/xml/ref-functions.xml
+++ b/src/guide/xml/ref-functions.xml
@@ -1049,7 +1049,7 @@ in that context.</para>
 </indexterm> processing instruction is a convenient mechanism
 for providing additional options to the stylesheets. But processing them
 is tedious. This function gathers together the pseudo-attributes specified
-in a series of processing instructions and returns the as attributes on
+in a series of processing instructions and returns them as attributes on
 an element. If the same property occurs more than once in the sequence,
 the last value will be returned.</para>
 </refsection>


### PR DESCRIPTION
"returns the as attributes" -> "returns them as attributes"