### PR TITLE
Fix #76, small cosmetic improvement in CSS

### DIFF
--- a/src/main/web/css/docbook.css
+++ b/src/main/web/css/docbook.css
@@ -315,6 +315,8 @@ code.email {
     background-color: inherit;
     border: inherit;
     font-size: 95%;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 pre code {

--- a/src/main/xslt/modules/bibliography.xsl
+++ b/src/main/xslt/modules/bibliography.xsl
@@ -115,6 +115,13 @@
   </xsl:choose>
 </xsl:template>
 
+<xsl:template match="db:releaseinfo" mode="m:bibliomixed">
+  <span>
+    <xsl:apply-templates select="." mode="m:attributes"/>
+    <xsl:apply-templates mode="m:biblioentry"/>
+  </span>
+</xsl:template>
+
 <!-- ============================================================ -->
 
 <xsl:template match="db:biblioset" mode="m:biblioentry">

--- a/src/test/resources/expected/bibliomixed.001.html
+++ b/src/test/resources/expected/bibliomixed.001.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" class="no-js"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Unit Test: bibliomixed.001</title><meta name="viewport" content="width=device-width, initial-scale=1.0"/><link href="http://purl.org/dc/elements/1.1/" rel="schema.dc"/><meta content="2011-04-22T17:02:00-06:00" name="dc.modified"/><meta content="DocBook xslTNG" name="generator"/><link href="./css/docbook.css" rel="stylesheet"/><link href="./css/docbook-screen.css" rel="stylesheet"/></head><body class="home"><nav class="top"></nav><main><article class="article"><header><h1>Unit Test: bibliomixed.001</h1></header><p>Test case for
+<a href="https://github.com/docbook/xslTNG/issues/76" class="link">issue 76</a>.</p><div class="bibliolist"><header><div class="title">Bibliography List</div></header>
+  
+
+  <p class="bibliomixed"><span class="biblioid">GCRT5021</span>, <cite class="title">Track System Requirements</cite>. Issue number: <span class="edition">5</span>. Issue date: <time class="pubdate">December 2011</time>. In-force date: <span class="releaseinfo">March 2012</span>. <span class="bibliomisc">Application conditions: Part 5</span>. </p>
+
+</div></article></main><nav class="bottom"></nav></body></html>

--- a/src/test/resources/xml/bibliomixed.001.xml
+++ b/src/test/resources/xml/bibliomixed.001.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink">
+<info>
+  <title>Unit Test: bibliomixed.001</title>
+</info>
+
+<para>Test case for
+<link xlink:href="https://github.com/docbook/xslTNG/issues/76">issue 76</link>.</para>
+
+<bibliolist>
+  <title>Bibliography List</title>
+
+  <bibliomixed><biblioid>GCRT5021</biblioid>, <title>Track System Requirements</title>. Issue number: <edition>5</edition>. Issue date: <pubdate>December 2011</pubdate>. In-force date: <releaseinfo>March 2012</releaseinfo>. <bibliomisc>Application conditions: Part 5</bibliomisc>. </bibliomixed>
+
+</bibliolist>
+
+</article>

--- a/src/test/xspec/bibliography.xspec
+++ b/src/test/xspec/bibliography.xspec
@@ -67,4 +67,9 @@
      <x:expect label="expect a bibliography" href="../resources/expected/bibliolist.004.html"/>
   </x:scenario>
 
+  <x:scenario label="When transforming a bibliomixed.001">
+     <x:context href="../resources/xml/bibliomixed.001.xml"/>
+     <x:expect label="expect a bibliography" href="../resources/expected/bibliomixed.001.html"/>
+  </x:scenario>
+
 </x:description>


### PR DESCRIPTION
This PR fixes #76 by adding a template for `releaseinfo` in `m:bibliomixed` mode.

It also fixes a minor CSS problem. In email addresses, which no longer have background color and border as "ordinary" inline code samlpes do, don't output extra padding before and after. (It puts, for example, extra space before a following comma.)