### PR TITLE
Remove erroneous colons after CSS selectors in docbook-paged.css.

### DIFF
--- a/src/main/web/css/docbook-paged.css
+++ b/src/main/web/css/docbook-paged.css
@@ -16,13 +16,13 @@
 }
 
 @page title {
-    @top-center: {
+    @top-center {
         content: "";
     }
-    @bottom-right: {
+    @bottom-right {
         content: "";
     }
-    @bottom-left: {
+    @bottom-left {
         content: "";
     }
 }
@@ -37,13 +37,13 @@
 }
 
 @page normal-flow:blank {
-    @top-center: {
+    @top-center {
         content: "";
     }
-    @bottom-right: {
+    @bottom-right {
         content: "";
     }
-    @bottom-left: {
+    @bottom-left {
         content: "";
     }
 }


### PR DESCRIPTION
This fixes creating PDFs with Prince. Previously, Prince would complain
about a parsing error and abort.

I have not tested it with Antenna House because I don't have a license for that. It shouldn't break anything since the `@top-*`, `@bottom-*` things are selectors, which shouldn't have colons