### PR TITLE
Fix #82 by adding a generate-html-page parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -933,6 +933,7 @@ task generateXSpecSources() {
 }
 testDrivers.each { driver ->
   tasks.findByName(driver).dependsOn generateXSpecSources
+  tasks.findByName(driver).dependsOn "makeXslt"
 }
 
 // Generate programlistingco/screeco results with all the possible stylings

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -1359,6 +1359,33 @@ C and other languages that use “;” as statement separator.
 </refsection>
 </refentry>
 
+<refentry xml:id="p_generate-html-page">
+<?db filename="p_generate-html-page.html"?>
+<refmeta>
+<refentrytitle>$generate-html-page</refentrytitle>
+<refmiscinfo>{}generate-html-page</refmiscinfo>
+</refmeta>
+<refnamediv>
+<refname>$generate-html-page</refname>
+<refpurpose>Generate the HTML page structure around the styled document</refpurpose>
+<refclass>param</refclass>
+</refnamediv>
+<refsection>
+<title>Description</title>
+<para>If this parameter <glossterm>is true</glossterm>, then a
+complete HTML page will be generated for the transformed document: an
+<tag>html</tag> tag, <tag>head</tag> and <tag>body</tag> tags, etc. If
+it’s false, then only the “raw” transformed content will be
+produced. This is true for both the primary output and any secondary result documents.</para>
+<note>
+<para>When the “raw” output option is selected, links to the CSS
+stylesheets, scripts, and other interactive features will not be
+generated. You must make sure those are provided in some other way.
+</para>
+</note>
+</refsection>
+</refentry>
+
 <refentry xml:id="p_generate-index">
 <?db filename="p_generate-index.html"?>
 <refmeta>

--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:db="http://docbook.org/ns/docbook"
                 xmlns:ext="http://docbook.org/extensions/xslt"
+                xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
@@ -12,7 +13,7 @@
                 xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
-                exclude-result-prefixes="db ext h m map mp t tp v vp xs"
+                exclude-result-prefixes="db ext f h m map mp t tp v vp xs"
                 version="3.0">
 
 <!-- This will all be in XProc 3.0 eventually, hack for now... -->
@@ -70,13 +71,30 @@
     </xsl:if>
   </xsl:for-each>
 
-  <xsl:sequence select="$result?output"/>
+  <xsl:choose>
+    <xsl:when test="f:is-true($generate-html-page)">
+      <xsl:sequence select="$result?output"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="$result?output/h:html/h:body/node()
+                            except $result?output/h:html/h:body/h:script"/>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <xsl:template match="node()" mode="m:chunk-write">
   <xsl:param name="href" as="xs:string" required="yes"/>
+
   <xsl:result-document href="{$href}">
-    <xsl:sequence select="."/>
+    <xsl:choose>
+      <xsl:when test="f:is-true($generate-html-page)">
+        <xsl:sequence select="."/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message>Attempting to generate raw output</xsl:message>
+        <xsl:sequence select="/h:html/h:body/node() except /h:html/h:body/h:script"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:result-document>
 </xsl:template>
 

--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -72,6 +72,9 @@
   </xsl:for-each>
 
   <xsl:choose>
+    <xsl:when test="not($result?output/h:html)">
+      <xsl:sequence select="$result?output"/>
+    </xsl:when>
     <xsl:when test="f:is-true($generate-html-page)">
       <xsl:sequence select="$result?output"/>
     </xsl:when>
@@ -87,6 +90,9 @@
 
   <xsl:result-document href="{$href}">
     <xsl:choose>
+      <xsl:when test="not(/h:html)">
+        <xsl:sequence select="$result?output"/>
+      </xsl:when>
       <xsl:when test="f:is-true($generate-html-page)">
         <xsl:sequence select="."/>
       </xsl:when>

--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -91,7 +91,7 @@
   <xsl:result-document href="{$href}">
     <xsl:choose>
       <xsl:when test="not(/h:html)">
-        <xsl:sequence select="$result?output"/>
+        <xsl:sequence select="."/>
       </xsl:when>
       <xsl:when test="f:is-true($generate-html-page)">
         <xsl:sequence select="."/>

--- a/src/main/xslt/param.xsl
+++ b/src/main/xslt/param.xsl
@@ -319,4 +319,6 @@
 
 <xsl:param name="default-theme" as="xs:string" select="''"/>
 
+<xsl:param name="generate-html-page" as="xs:string" select="'true'"/>
+
 </xsl:stylesheet>


### PR DESCRIPTION
If the `generate-html-page` parameter is true (the default), then an entire HTML page is generated for each document. If it's false, then only the rendered elements are returned. This means the result will not have `html`, `head`, or `body` tags. 