### PR TITLE
Fix #84 by always outputting non-HTML contents and adding docs

### DIFF
--- a/src/guide/xml/ch03.xml
+++ b/src/guide/xml/ch03.xml
@@ -162,4 +162,52 @@ processing. The effect of this template is to wrap an HTML
 but I’m trying to keep the example simple.</para>
 
 </section>
+
+<section xml:id="different">
+<title>Creating something completely different</title>
+
+<para>Your input documents go through several pre-processing steps
+before they are rendered into HTML. If you want to produce completely
+different outputs, the place to start is with root template in the
+<mode>m:docbook</mode> mode.</para>
+
+<para>Consider, <link xlink:href="https://github.com/docbook/xslTNG/issues/84">for example</link>,
+the task of creating a JSON version of the Table of Contents. In principle, you could
+write your own stylesheet to do this, but leveraging the
+<citetitle>DocBook xslTNG Stylesheets</citetitle> means you can make use of functions like
+<function>f:generate-id</function> to create links.</para>
+
+<para>To produce completely different results, override the root template in the
+<mode>m:docbook</mode> mode:</para>
+
+<programlisting language="xml"><![CDATA[<xsl:template match="/" mode="m:docbook">
+  <xsl:document>
+    <!-- your processing here -->
+  </xsl:document>
+</xsl:template>]]></programlisting>
+
+<para>This template <emphasis>must</emphasis> return a document node.</para>
+
+<para>Note that you can mix-and-match your processing with default
+processing by processing DocBook elements in the
+<mode>m:docbook</mode> mode.</para>
+
+<para>Here is a simple example of a stylesheet that produces a JSON version of the
+Table of Contents for a DocBook document:</para>
+
+<programlisting language="xml"
+><xi:include href="examples/issue84.xsl" parse="text"/></programlisting>
+
+<note>
+<para>This example is meant as a starting point; it’s not robust as it only handles
+a few of the possible elements that might appear in a Table of Contents.</para>
+</note>
+
+<para>When processing documents this way, be aware that you are transforming the pre-processed,
+normalized versions of your input documents. For example, whether or not you put
+<tag>info</tag> wrappers around the titles of your sections, in the pre-processed input,
+<tag>title</tag>s <emphasis>always</emphasis> appear inside <tag>info</tag> wrappers.
+This normalization greatly simplifies processing in many places.</para>
+</section>
+
 </chapter>

--- a/src/guide/xml/examples/issue84.xsl
+++ b/src/guide/xml/examples/issue84.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:db="http://docbook.org/ns/docbook"
+                xmlns:f="http://docbook.org/ns/docbook/functions"
+                xmlns:m="http://docbook.org/ns/docbook/modes"
+                xmlns:t="http://docbook.org/ns/docbook/templates"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="http://www.w3.org/1999/xhtml"
+                exclude-result-prefixes="db f m t xs"
+                version="3.0">
+
+  <!-- This href has to point to your local copy
+       of the stylesheets. -->
+  <xsl:import href="docbook/xslt/docbook.xsl"/>
+
+  <xsl:output method="text"/>
+
+  <!-- Suppress xslTNG's default HTML output; note that this template
+       must return a docuent node.  -->
+  <xsl:template match="/" mode="m:docbook">
+    <xsl:document>
+      <xsl:apply-templates select="." mode="TOC"/>
+    </xsl:document>
+  </xsl:template>
+
+  <!-- The templates below generate a simple JSON ToC. -->
+
+  <xsl:template match="/" mode="TOC">
+    {"toc": [
+    <xsl:apply-templates mode="TOC"/>
+    ]}
+  </xsl:template>
+
+  <xsl:template match="db:part|db:article|db:section|db:chapter" mode="TOC"
+                expand-text="yes">
+    <xsl:if test="preceding-sibling::db:part
+                  | preceding-sibling::db:article
+                  | preceding-sibling::db:section
+                  | preceding-sibling::db:chapter">,&#10;</xsl:if>
+    {{
+    "ref": "{f:generate-id(.)}",
+    "title": "{normalize-space(db:info/db:title)}",
+    "subtitle": "{normalize-space(db:info/db:subtitle)}",
+    "items": [
+    <xsl:apply-templates select="db:part|db:article|db:section|db:chapter" mode="TOC"/>
+    ]
+    }}
+  </xsl:template>
+
+  <xsl:template match="*" mode="TOC">
+    <xsl:apply-templates select="*" mode="TOC"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/xslt/modules/chunk-output.xsl
+++ b/src/main/xslt/modules/chunk-output.xsl
@@ -19,7 +19,14 @@
   <xsl:choose>
     <xsl:when test="not($v:chunk)">
       <xsl:variable name="result">
-        <xsl:apply-templates select="/h:html/h:html"/>
+        <xsl:choose>
+          <xsl:when test="/h:html/h:html">
+            <xsl:apply-templates select="/h:html/h:html"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="."/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:variable>
       <xsl:sequence select="map {'output': $result}"/>
     </xsl:when>


### PR DESCRIPTION
This PR adds documentation and an example of how to produce completely different outputs.

It also fixes the bug that prevented this from working for outputs that weren't HTML pages! :-)