### PR TITLE
Generate id attribute for <row> element

### DIFF
--- a/src/main/xslt/modules/tablecals.xsl
+++ b/src/main/xslt/modules/tablecals.xsl
@@ -94,6 +94,9 @@
   <xsl:message use-when="'tables' = $debug"
                select="'========================================'"/>
   <tr>
+    <xsl:if test="@xml:id">
+      <xsl:attribute name="id" select="@xml:id"/>
+    </xsl:if>
     <xsl:for-each select="1 to fcals:table-columns($row)">
       <xsl:variable name="cell" select="fcals:cell($row, ., $overhang, $cells)"/>
       <xsl:choose>
@@ -248,7 +251,7 @@
   <xsl:variable name="table"
                 select="($row/ancestor::db:table
                          |$row/ancestor::db:informaltable)[last()]"/>
-  
+
   <xsl:variable name="table-part"
                 select="($row/ancestor::db:thead
                          |$row/ancestor::db:tbody


### PR DESCRIPTION
I had to close https://github.com/docbook/xslTNG/pull/96 because I accidently deleted my fork.  I don't know whether it would be better to move the generation of the id attribute into a template in m:attributes mode.  This is a very targeted approach. Do you mean <xsl:apply-templates select="." mode="m:attributes"/>?