### PR TITLE
Adding an annotation-placement parameter

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -261,6 +261,31 @@ are numbered and the annotations appear as a form of footnote.</para>
 </refsection>
 </refentry>
 
+<refentry xml:id="p_annotation-placement">
+<?db filename="p_annotation-placement.html"?>
+<refmeta>
+<refentrytitle>$annotation-placement</refentrytitle>
+<refmiscinfo>{}annotation-placement</refmiscinfo>
+</refmeta>
+<refnamediv>
+<refname>$annotation-placement</refname>
+<refpurpose>Determines where the annotation mark is placed</refpurpose>
+<refclass>param</refclass>
+</refnamediv>
+<refsection>
+<title>Description</title>
+<para>When <tag>annotation</tag>s are rendered,
+<parameter>annotation-placement</parameter> determines where the
+<parameter>annotation-mark</parameter> is placed. If the value is <literal>after</literal>,
+the mark or marks are placed at the very end of the element being annotated.
+If the value is <literal>before</literal>, the marks are placed at the very beginning
+of the element being annotated. 
+</para>
+<para>Each individual annotation can determine it’s placement by placing <literal>before</literal>
+or <literal>after</literal> in its <tag class="attribute">role</tag> attribute.</para>
+</refsection>
+</refentry>
+
 <refentry xml:id="p_annotation-style">
 <?db filename="p_annotation-style.html"?>
 <refmeta>

--- a/src/main/xslt/drivers.xsl
+++ b/src/main/xslt/drivers.xsl
@@ -104,7 +104,10 @@
                  select="'Preprocess: annotations'"/>
     <xsl:sequence select="transform(map {
       'stylesheet-location': 'transforms/60-annotations.xsl',
-      'source-node': $source
+      'source-node': $source,
+      'stylesheet-params': map {
+         QName('', 'annotation-placement'): $annotation-placement
+       }
       })?output"/>
   </xsl:variable>
 

--- a/src/main/xslt/modules/annotations.xsl
+++ b/src/main/xslt/modules/annotations.xsl
@@ -15,6 +15,7 @@
   <xsl:variable name="number"
                 select="count(key('id', @linkend)/preceding::db:annotation)+1"/>
   <db-annotation-marker target="{@linkend}"
+                        placement="{@placement}"
                         db-annotation="{$number}">
     <a class="annomark" href="#{@linkend}"
        db-annotation="{@linkend}">

--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -33,7 +33,9 @@
 </xsl:template>
 
 <xsl:template match="h:db-annotation-marker">
-  <xsl:apply-templates/>
+  <xsl:if test="not(@placement = 'before')">
+    <xsl:apply-templates/>
+  </xsl:if>
 </xsl:template>
 
 <xsl:template match="*[@db-chunk]" priority="10">
@@ -425,7 +427,9 @@
 
 <xsl:template match="element()">
   <xsl:copy>
-    <xsl:apply-templates select="@*,node()"/>
+    <xsl:apply-templates select="@*"/>
+    <xsl:sequence select="h:db-annotation-marker[@placement='before']/node()"/>
+    <xsl:apply-templates select="node()"/>
   </xsl:copy>
 </xsl:template>
 

--- a/src/main/xslt/param.xsl
+++ b/src/main/xslt/param.xsl
@@ -162,6 +162,7 @@
 
 <xsl:param name="annotation-style" select="'javascript'"/>
 <xsl:param name="annotation-mark"><sup>⌖</sup></xsl:param>
+<xsl:param name="annotation-placement" select="'after'"/>
 
 <xsl:param name="xlink-style" select="'document'"/>
 <xsl:param name="xlink-style-default" select="'inline'"/>

--- a/src/main/xslt/transforms/60-annotations.xsl
+++ b/src/main/xslt/transforms/60-annotations.xsl
@@ -10,31 +10,31 @@
 
 <xsl:import href="../modules/shared.xsl"/>
 
+<xsl:param name="annotation-placement" select="'after'"/>
+
 <xsl:key name="annotations" match="db:annotation" use="@xml:id"/>
 
 <xsl:template match="/">
-  <xsl:document>
-    <xsl:apply-templates/>
-  </xsl:document>
-</xsl:template>
+  <xsl:if test="$annotation-placement != 'before'
+                and $annotation-placement != 'after'">
+    <xsl:message terminate="yes"
+                 >The $annotation-placement parameter must be ‘before’ or ‘after’</xsl:message>
+  </xsl:if>
 
-<!-- Move all the actual annotations to the end of the document -->
-<xsl:template match="/*" priority="100">
-  <xsl:copy>
-    <xsl:apply-templates select="@*,node()"/>
-    <!-- Make sure annotations have xml:id attributes! -->
-    <xsl:for-each select="//db:annotation">
-      <xsl:copy>
-        <xsl:if test="empty(@xml:id)">
-          <xsl:attribute name="xml:id" select="f:generate-id(.)"/>
-        </xsl:if>
-        <xsl:copy-of select="@*,node()"/>
-      </xsl:copy>
-    </xsl:for-each>
-  </xsl:copy>
+  <xsl:choose>
+    <xsl:when test="empty(//db:annotation)">
+      <xsl:sequence select="."/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:variable name="doc">
+        <xsl:apply-templates select="node()" mode="mp:move-to-end"/>
+      </xsl:variable>
+      <xsl:document>
+        <xsl:apply-templates select="$doc/node()"/>
+      </xsl:document>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
-
-<xsl:template match="db:annotation" priority="100"/>
 
 <!-- Output a ghost:annotation everywhere an annotation is used -->
 <xsl:template match="*[@xml:id] | *[@annotations]">
@@ -46,12 +46,27 @@
 
   <xsl:variable name="annotations" select="($points-to-me union $i-point-to)"/>
 
-  <xsl:copy>
-    <xsl:apply-templates select="@*,node()"/>
+  <xsl:variable name="before-annotations" as="element(db:annotation)*">
     <xsl:for-each select="$annotations">
-      <ghost:annotation>
-        <xsl:attribute name="linkend" select="f:generate-id(.)"/>
-      </ghost:annotation>
+      <xsl:if test="$annotation-placement = 'before'
+                    or (contains-token(@role, 'before')
+                        and not(contains-token(@role, 'after')))">
+        <xsl:sequence select="."/>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:variable>
+
+  <xsl:variable name="after-annotations" as="element(db:annotation)*"
+                select="$annotations except $before-annotations"/>
+
+  <xsl:copy>
+    <xsl:apply-templates select="@*"/>
+    <xsl:for-each select="$before-annotations">
+      <ghost:annotation linkend="{f:generate-id(.)}" placement="before"/>
+    </xsl:for-each>
+    <xsl:apply-templates select="node()"/>
+    <xsl:for-each select="$after-annotations">
+      <ghost:annotation linkend="{f:generate-id(.)}" placement="after"/>
     </xsl:for-each>
   </xsl:copy>
 </xsl:template>
@@ -63,6 +78,35 @@
 </xsl:template>
 
 <xsl:template match="attribute()|text()|comment()|processing-instruction()">
+  <xsl:copy/>
+</xsl:template>
+
+<!-- ============================================================ -->
+
+<xsl:template match="/*" priority="100" mode="mp:move-to-end">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()" mode="mp:move-to-end"/>
+    <xsl:for-each select="//db:annotation">
+      <xsl:copy>
+        <xsl:if test="empty(@xml:id)">
+          <xsl:attribute name="xml:id" select="f:generate-id(.)"/>
+        </xsl:if>
+        <xsl:sequence select="@*,node()"/>
+      </xsl:copy>
+    </xsl:for-each>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="db:annotation" priority="100" mode="mp:move-to-end"/>
+
+<xsl:template match="element()" mode="mp:move-to-end">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()" mode="mp:move-to-end"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="attribute()|text()|comment()|processing-instruction()"
+              mode="mp:move-to-end">
   <xsl:copy/>
 </xsl:template>
 

--- a/src/test/resources/expected/annotations.005.html
+++ b/src/test/resources/expected/annotations.005.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" class="no-js"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><script>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script><title>Article wrapper</title><meta name="viewport" content="width=device-width, initial-scale=1.0"/><link href="https://purl.org/dc/elements/1.1/" rel="schema.dc"/><meta content="2011-04-22T17:02:00-06:00" name="dc.modified"/><meta content="DocBook xslTNG" name="generator"/><link href="./css/docbook.css" rel="stylesheet"/><link href="./css/docbook-screen.css" rel="stylesheet"/></head><body class="home"><nav class="top"></nav><main><article id="anno" class="article"><a class="annomark" href="#anno_info1_annotation4" db-annotation="anno_info1_annotation4"><sup>⌖</sup><sup class="num">4</sup></a><header><h1>Article wrapper</h1></header><div class="list-of-titles"><div class="lot toc"><div class="title">Table of Contents</div><ul class="toc"><li><a href="#s1"><span class="number">1<span class="sep"> </span></span>Section title</a></li><li><a href="#s2"><span class="number">2<span class="sep"> </span></span>Section title</a></li></ul></div></div><p><a class="annomark" href="#before" db-annotation="before"><sup>⌖</sup><sup class="num">1</sup></a>This article tests <span id="an1" class="phrase"><a class="annomark" href="#anno_info1_annotation3" db-annotation="anno_info1_annotation3"><sup>⌖</sup><sup class="num">3</sup></a>annotations</span>.
+<span id="an2" class="phrase"><a class="annomark" href="#anno_info1_annotation3" db-annotation="anno_info1_annotation3"><sup>⌖</sup><sup class="num">3</sup></a>Annotations</span>
+can point in either direction. This paragraph contains
+<span id="an3" class="phrase"><a class="annomark" href="#anno_info1_annotation3" db-annotation="anno_info1_annotation3"><sup>⌖</sup><sup class="num">3</sup></a>annotation</span> targets.</p><p>This paragraph asserts that it is annotated
+by the annotation “after”.<a class="annomark" href="#after"><sup>⌖</sup><sup class="num">2</sup></a></p><section id="s1" class="section"><a class="annomark" href="#anno_info1_annotation4" db-annotation="anno_info1_annotation4"><sup>⌖</sup><sup class="num">4</sup></a><header><h2><span class="number">1<span class="sep"> </span></span>Section title</h2></header><p>This is a section.
+Lorem ipsum dolor sit amet, consectetaur adipisicing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum Et harumd und
+lookum like Greek to me, dereud facilis est er expedit distinct. Nam
+liber te conscient to factor tum poen legum odioque civiuda.
+</p><a class="annomark" href="#anno_info1_annotation5"><sup>⌖</sup><sup class="num">5</sup></a></section><section id="s2" class="section"><header><h2><span class="number">2<span class="sep"> </span></span>Section title</h2></header><p>This is a section.
+Lorem ipsum dolor sit amet, consectetaur adipisicing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum Et harumd und
+lookum like Greek to me, dereud facilis est er expedit distinct. Nam
+liber te conscient to factor tum poen legum odioque civiuda.
+</p></section><a class="annomark" href="#anno_info1_annotation5"><sup>⌖</sup><sup class="num">5</sup></a></article></main><footer><div class="annotations"><div class="annotation-wrapper title">Annotations</div><div id="anno_info1_annotation4" class="annotation-wrapper before"><div class="annotation-body"><div class="annotation-header"><div class="annotation-close"></div><div class="annotation-title"><span class="annomark"><sup>⌖</sup><sup class="num">4</sup> </span></div></div><div class="annotation-content">
+<p>At the very beginning of the article and the first section.</p>
+</div></div></div><div id="before" class="annotation-wrapper before"><div class="annotation-body"><div class="annotation-header"><div class="annotation-close"></div><div class="annotation-title"><span class="annomark"><sup>⌖</sup><sup class="num">1</sup> </span>This is a “before” annotation</div></div><div class="annotation-content">
+
+<p>The mark for this annotation occurs at the beginning
+of the element that it annotates.</p>
+</div></div></div><div id="anno_info1_annotation3" class="annotation-wrapper before"><div class="annotation-body"><div class="annotation-header"><div class="annotation-close"></div><div class="annotation-title"><span class="annomark"><sup>⌖</sup><sup class="num">3</sup> </span></div></div><div class="annotation-content">
+<p>This annotation pointlessly annotates every occurrence of the word “annotation”
+in the first paragraph of the article. The annotation mark occurs at the
+beginning of the word.</p></div></div></div><div id="after" class="after annotation-wrapper"><div class="annotation-body"><div class="annotation-header"><div class="annotation-close"></div><div class="annotation-title"><span class="annomark"><sup>⌖</sup><sup class="num">2</sup> </span>This is an “after” annotation</div></div><div class="annotation-content">
+
+<p>The mark for this annotation occurs at the end
+of the element that it annotates.</p>
+</div></div></div><div id="anno_info1_annotation5" class="after annotation-wrapper"><div class="annotation-body"><div class="annotation-header"><div class="annotation-close"></div><div class="annotation-title"><span class="annomark"><sup>⌖</sup><sup class="num">5</sup> </span></div></div><div class="annotation-content">
+<p>At the very end of the article and the first section.</p>
+</div></div></div></div></footer><nav class="bottom"></nav><script type="text/html" class="annotation-close"><span>╳</span></script><script src="./js/annotations.js"></script></body></html>

--- a/src/test/resources/xml/annotations.005.xml
+++ b/src/test/resources/xml/annotations.005.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="anno">
+<info>
+<title>Article wrapper</title>
+<annotation xml:id="before" role="before">
+<title>This is a “before” annotation</title>
+<para>The mark for this annotation occurs at the beginning
+of the element that it annotates.</para>
+</annotation>
+<annotation xml:id="after" role="after">
+<title>This is an “after” annotation</title>
+<para>The mark for this annotation occurs at the end
+of the element that it annotates.</para>
+</annotation>
+<annotation annotates="an1 an2 an3" role="before">
+<para>This annotation pointlessly annotates every occurrence of the word “annotation”
+in the first paragraph of the article. The annotation mark occurs at the
+beginning of the word.</para></annotation>
+<annotation annotates="anno s1" role="before">
+<para>At the very beginning of the article and the first section.</para>
+</annotation>
+<annotation annotates="anno s1" role="after">
+<para>At the very end of the article and the first section.</para>
+</annotation>
+</info>
+
+<para annotations="before">This article tests <phrase xml:id="an1">annotations</phrase>.
+<phrase xml:id="an2">Annotations</phrase>
+can point in either direction. This paragraph contains
+<phrase xml:id="an3">annotation</phrase> targets.</para>
+
+<para annotations="after">This paragraph asserts that it is annotated
+by the annotation “after”.</para>
+
+<section xml:id="s1">
+<title>Section title</title>
+<para>This is a section.
+Lorem ipsum dolor sit amet, consectetaur adipisicing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum Et harumd und
+lookum like Greek to me, dereud facilis est er expedit distinct. Nam
+liber te conscient to factor tum poen legum odioque civiuda.
+</para>
+</section>
+
+<section xml:id="s2">
+<title>Section title</title>
+<para>This is a section.
+Lorem ipsum dolor sit amet, consectetaur adipisicing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum Et harumd und
+lookum like Greek to me, dereud facilis est er expedit distinct. Nam
+liber te conscient to factor tum poen legum odioque civiuda.
+</para>
+</section>
+
+</article>

--- a/src/test/xspec/annotations.xspec
+++ b/src/test/xspec/annotations.xspec
@@ -21,4 +21,9 @@
       <x:context href="../resources/xml/annotations.004.xml"/>
       <x:expect label="expect multiple annotation marks" href="../resources/expected/annotations.004.html"/>
    </x:scenario>
+
+   <x:scenario label="When transforming annotations.005">
+      <x:context href="../resources/xml/annotations.005.xml"/>
+      <x:expect label="expect multiple annotation marks" href="../resources/expected/annotations.005.html"/>
+   </x:scenario>
 </x:description>


### PR DESCRIPTION
Fix #113 

The `$annotation-placement` parameter specifies whether annotation marks should appear at the *very* beginning of the element to which they apply (placement = `before`) or at the very end (placement = `after`, the default).

Individual annotations can position themselves at the beginning or the end with a role attribute value of `before` or `after`.