### PR TITLE
Bug fixes and improvements to the persistent ToC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1582,6 +1582,14 @@ task stageJar(
     copy {
       into "${buildDir}/resources/main/org/docbook/xsltng/resources"
       from "${projectDir}/src/main/web"
+      filter { String line ->
+        if (line.indexOf("@@") >= 0) {
+          line = line
+            .replace("@@TITLE@@", xslTNGtitle)
+            .replace("@@VERSION@@", xslTNGversion)
+        }
+        line
+      }
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,8 @@ relaxng_validate.configure {
 // If this is running on the CI infrastructure and it's not
 // a tagged build, add -SNAPSHOT to the version.
 if (System.getenv()["CIRCLECI"] == "true"
-    && System.getenv()["CIRCLE_TAG"] == null) {
+    && System.getenv()["CIRCLE_TAG"] == null
+    && !xslTNGversion.contains('SNAPSHOT')) {
   xslTNGversion = xslTNGversion + "-SNAPSHOT"
 }
 

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.5.1'
-  guideVersion = '1.5.1'
+  xslTNGversion = '1.5.2-SNAPSHOT'
+  guideVersion = '1.5.2-SNAPSHOT'
 
   docbookSchemaVersion = '5.2b10a4'
 

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.5.2-SNAPSHOT'
-  guideVersion = '1.5.2-SNAPSHOT'
+  xslTNGversion = '1.5.2'
+  guideVersion = '1.5.2'
 
   docbookSchemaVersion = '5.2b10a4'
 

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -281,7 +281,7 @@ the mark or marks are placed at the very end of the element being annotated.
 If the value is <literal>before</literal>, the marks are placed at the very beginning
 of the element being annotated. 
 </para>
-<para>Each individual annotation can determine it’s placement by placing <literal>before</literal>
+<para>Each individual annotation can determine its placement by placing <literal>before</literal>
 or <literal>after</literal> in its <tag class="attribute">role</tag> attribute.</para>
 </refsection>
 </refentry>

--- a/src/main/web/js/persistent-toc.js
+++ b/src/main/web/js/persistent-toc.js
@@ -10,7 +10,7 @@
   const ESC = 27;
   const SPACE = 32;
   const toc = document.querySelector("nav.toc");
-  let navPersist = false;
+  let tocPersist = null;
   let borderLeftColor = "white";
   let curpress = null;
   let searchListener = false;
@@ -21,11 +21,19 @@
     toc.style["padding-right"] = "1em";
     toc.style["border-left"] = `1px solid ${borderLeftColor}`;
 
-    navPersist = event && event.shiftKey;
+    // Make sure the tocPersist checkbox is created
+    tocPersistCheckbox();
 
     if (event) {
       event.preventDefault();
     }
+
+    // Turn off any search markers that might have been set
+    toc.querySelectorAll("li").forEach(function (li) {
+      const link = li.querySelector("a");
+      li.style.display = "list-item";
+      link.classList.remove("found");
+    });
 
     // Give the current click event a chance to settle?
     window.setTimeout(function () {
@@ -59,7 +67,10 @@
       
       pos = url.indexOf("?");
       if (pos >= 0) {
-        navPersist = true;
+        tocPersistCheckbox();
+        if (tocPersist) {
+          tocPersist.checked = true;
+        }
         url = url.substring(0, pos);
       }
       url = url + hash;
@@ -74,7 +85,17 @@
       if (target) {
         target.scrollIntoView();
       } else {
-        console.log("No target:" + url);
+        // Maybe it's just a link in this page?
+        pos = url.indexOf("#");
+        if (pos > 0) {
+          let hash = url.substring(pos);
+          target = document.querySelector("nav.toc div a[href='"+hash+"']");
+          if (target) {
+            target.scrollIntoView();
+          } else {
+            console.log(`No target: ${url} (or ${hash})`);
+          }
+        }
       }
 
       if (!searchListener) {
@@ -93,7 +114,10 @@
     toc.style["padding-left"] = "0";
     toc.style["padding-right"] = "0";
     toc.style["border-left"] = "none";
-    event.preventDefault();
+
+    if (event) {
+      event.preventDefault();
+    }
 
     const searchp = toc.querySelector(".ptoc-search");
     if (searchp) {
@@ -109,14 +133,41 @@
     return false;
   };
 
+  const tocPersistCheckbox = function() {
+    if (tocPersist != null) {
+      return;
+    }
+
+    let ptoc = toc.querySelector("p.ptoc-search");
+    let sbox = ptoc.querySelector("input.ptoc-search");
+    if (sbox) {
+      sbox.setAttribute("title", "Simple text search in ToC");
+      let pcheck = document.createElement("input");
+      pcheck.classList.add("persist");
+      pcheck.setAttribute("type", "checkbox");
+      pcheck.setAttribute("title", "Keep ToC open when following links");
+      pcheck.checked = (window.location.href.indexOf("?toc") >= 0);
+      ptoc.appendChild(pcheck);
+    }
+
+    tocPersist = toc.querySelector("p.ptoc-search .persist");
+  };
+
   const patchLink = function(event, anchor) {
-    if (!navPersist) {
+    if (!tocPersist || !tocPersist.checked) {
       return false;
     }
 
     let href = anchor.getAttribute("href");
     let pos = href.indexOf("#");
-    if (pos >= 0) {
+
+    if (pos === 0) {
+      // If the anchor is a same-document reference, we don't
+      // need to do any of this query string business.
+      return false;
+    }
+
+    if (pos > 0) {
       href = href.substring(0, pos) + "?toc" + href.substring(pos);
     } else {
       href = href + "?toc";
@@ -193,6 +244,9 @@
 
   document.querySelectorAll("nav.toc div a").forEach(function (anchor) {
     anchor.onclick = function(event) {
+      if (!tocPersist || !tocPersist.checked) {
+        hideToC();
+      }
       patchLink(event, anchor);
     };
   });

--- a/src/main/xslt/transforms/60-annotations.xsl
+++ b/src/main/xslt/transforms/60-annotations.xsl
@@ -150,9 +150,8 @@
 
   <xsl:variable name="before-annotations" as="element(db:annotation)*">
     <xsl:for-each select="$annotations">
-      <xsl:if test="$annotation-placement = 'before'
-                    or (contains-token(@role, 'before')
-                        and not(contains-token(@role, 'after')))">
+      <xsl:if test="($annotation-placement = 'before' and not(contains-token(@role, 'after')))
+                    or contains-token(@role, 'before')">
         <xsl:sequence select="."/>
       </xsl:if>
     </xsl:for-each>


### PR DESCRIPTION
* Fix a typo
* Fix #118 
* Fix #119 
* Improve the persistent ToC. Browsers don't really afford holding down shift or meta/alt or anything else so make a checkbox for keeping the persistent ToC open; not the most accessible UX, but... Also fixed bugs where the search hit markers would sometimes persist and the link target computation didn't work for same-document links.