### PR TITLE
Bump XML Resolver version, push new release

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.5.3'
-  guideVersion = '1.5.3'
+  xslTNGversion = '1.5.4'
+  guideVersion = '1.5.4'
 
   docbookVersion = '5.2b11'
   publishersVersion = '5.2b11'
@@ -16,7 +16,7 @@ ext {
 
   metadataExtractorVersion = '2.15.0'
   jingVersion = '20181222'
-  xmlresolverVersion = '3.0.2'
+  xmlresolverVersion = '3.1.0'
   sincludeVersion = '2.0.0'
   slf4jVersion = '1.7.30'
 }


### PR DESCRIPTION
There's a bug in XML Resolver 3.0.1 that causes it to fail for all JDK releases from 9 on. That's been fixed, pushing this release to update the dependency for the convenience of end users.
