### PR TITLE
DocBook xslTNG version 1.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     machine:
       image: ubuntu-1604:202004-01
-    resource_class: 2xlarge
+    resource_class: xlarge
 
     working_directory: ~/repo
 

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,13 +2,13 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.5.4'
-  guideVersion = '1.5.4'
+  xslTNGversion = '1.6.0'
+  guideVersion = '1.6.0'
 
-  docbookVersion = '5.2b11'
-  publishersVersion = '5.2b11'
+  docbookVersion = '5.2b12'
+  publishersVersion = '5.2b12'
 
-  saxonVersion = '10.5'
+  saxonVersion = '10.6'
   saxonGroup = 'net.sf.saxon'
   saxonEdition = 'Saxon-HE'
   //saxonGroup = 'com.saxonica'
@@ -17,6 +17,6 @@ ext {
   metadataExtractorVersion = '2.15.0'
   jingVersion = '20181222'
   xmlresolverVersion = '3.1.0'
-  sincludeVersion = '2.0.0'
+  sincludeVersion = '4.0.0'
   slf4jVersion = '1.7.30'
 }

--- a/src/main/web/css/docbook.css
+++ b/src/main/web/css/docbook.css
@@ -1334,6 +1334,10 @@ li[db-mark='box'] {
     color: var(--on-sidebar-color);
 }
 
+.sidebar code {
+    background-color: var(--sidebar-color);
+}
+
 /* ============================================================ */
 
 .msgexplan {

--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -343,6 +343,17 @@
   <xsl:variable name="pchunk" select="(ancestor::*[@db-chunk])[last()]"/>
   <xsl:variable name="tchunk" select="($target/ancestor-or-self::*[@db-chunk])[last()]"/>
 
+  <xsl:if test="$target[1]/@db-chunk and count($target) != 1">
+    <xsl:choose>
+      <xsl:when test="count($target) = 0">
+        <xsl:message select="'Error: cannot find ' || $id || ' in document'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message select="'Error: multiple elements match ' || $id || ' in document'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:if>
+
   <xsl:choose>
     <xsl:when test="empty($target)">
       <xsl:message select="'No id for #' || $id"/>

--- a/src/main/xslt/modules/programming.xsl
+++ b/src/main/xslt/modules/programming.xsl
@@ -711,7 +711,8 @@
 
 <!-- ============================================================ -->
 
-<xsl:template match="db:classsynopsis
+<xsl:template match="db:packagesynopsis
+                     |db:classsynopsis
                      |db:fieldsynopsis
                      |db:methodsynopsis
                      |db:constructorsynopsis
@@ -721,6 +722,28 @@
     <xsl:message select="'Warning: no explicit support for', @language, 'synopses.'"/>
   </xsl:if>
   <xsl:next-match/>
+</xsl:template>
+
+<xsl:template match="db:packagesynopsis">
+  <xsl:param name="indent" select="''"/>
+
+  <xsl:variable name="package" select="db:package"/>
+  <xsl:if test="count($package) != 1">
+    <xsl:message>Malformed packagesynopisis.</xsl:message>
+  </xsl:if>
+
+  <div>
+    <xsl:apply-templates select="." mode="m:attributes"/>
+    <pre>
+      <xsl:apply-templates select="$package/preceding-sibling::*" mode="m:synopsis"/>
+      <xsl:text>package </xsl:text>
+      <xsl:apply-templates select="db:package"/>
+      <xsl:text>;&#10;</xsl:text>
+    </pre>
+    <xsl:apply-templates select="$package/following-sibling::*">
+      <xsl:with-param name="indent" select="$indent || $classsynopsis-indent"/>
+    </xsl:apply-templates>
+  </div>
 </xsl:template>
 
 <xsl:template match="db:classsynopsis">

--- a/src/test/resources/element-list.xml
+++ b/src/test/resources/element-list.xml
@@ -205,9 +205,7 @@ stylesheet which does not, technically, treat it like a DocBook document.</para>
 <member>msgsub</member>
 <member>msgtext</member>
 <member>multimediaparam</member>
-<member>namespace</member>
-<member>namespacename</member>
-<member>namespacesynopsis</member>
+<member>packagesynopsis</member>
 <member>nonterminal</member>
 <member>note</member>
 <member>olink</member>

--- a/src/test/resources/expected/packagesynopsis.001.html
+++ b/src/test/resources/expected/packagesynopsis.001.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" class="no-js"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><script>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script><title>Unit test: packagesynopsis.001</title><meta name="viewport" content="width=device-width, initial-scale=1.0"/><link href="https://purl.org/dc/elements/1.1/" rel="schema.dc"/><meta content="2011-04-22T17:02:00-06:00" name="dc.modified"/><meta content="DocBook xslTNG" name="generator"/><link href="./css/docbook.css" rel="stylesheet"/><link href="./css/docbook-screen.css" rel="stylesheet"/></head><body class="home"><nav class="top"></nav><main><article class="article"><header><h1>Unit test: packagesynopsis.001</h1></header><div id="package" class="packagesynopsis"><pre>package <code class="package">org.example.package</code>;
+</pre><div id="class" class="classsynopsis"><div class="pre-wrap"><pre class="classsynopsisinfo verbatim"><code>// This is just a made up example.
+// Mostly.</code></pre></div><pre>public class Catalog {
+  <span class="fieldsynopsis">public static final int <span class="varname">BASE</span> = <span class="initializer">CatalogEntry.addEntryType("BASE", 1)</span>;</span>
+  <span class="constructorsynopsis">public Catalog();
+</span>  <span class="methodsynopsis">protected copyReaders(<span class="methodparam">Catalog newCatalog</span>);</span>
+}</pre></div></div></article></main><nav class="bottom"></nav></body></html>

--- a/src/test/resources/xml/packagesynopsis.001.xml
+++ b/src/test/resources/xml/packagesynopsis.001.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Unit test: packagesynopsis.001</title>
+
+<packagesynopsis xml:id="package" language="java">
+<package>org.example.package</package>
+<classsynopsis xml:id="class">
+  <ooclass>
+    <modifier>public</modifier>
+    <classname>Catalog</classname>
+  </ooclass>
+  <classsynopsisinfo><?db verbatim-style='plain'?>// This is just a made up example.
+// Mostly.</classsynopsisinfo>
+  <fieldsynopsis>
+    <modifier>public</modifier>
+    <modifier>static</modifier>
+    <modifier>final</modifier>
+    <type>int</type>
+    <varname>BASE</varname>
+    <initializer>CatalogEntry.addEntryType("BASE", 1)</initializer>
+  </fieldsynopsis>
+  <constructorsynopsis>
+    <modifier>public</modifier>
+    <methodname>Catalog</methodname>
+    <void/>
+  </constructorsynopsis>
+  <methodsynopsis>
+    <modifier>protected</modifier>
+    <void/>
+    <methodname>copyReaders</methodname>
+    <methodparam>
+      <type>Catalog</type>
+      <parameter>newCatalog</parameter>
+    </methodparam>
+  </methodsynopsis>
+</classsynopsis>
+</packagesynopsis>
+</article>


### PR DESCRIPTION
* Minor CSS and debug message fixes
* Support DocBook 5.2b12; `namespacesynopsis` -> `packagesynopsis`