### PR TITLE
Fix locales in the repo

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.6.1'
-  guideVersion = '1.6.1'
+  xslTNGversion = '1.6.2'
+  guideVersion = '1.6.2'
 
   docbookVersion = '5.2b12'
   publishersVersion = '5.2b12'

--- a/src/main/locales/locale/af.xml
+++ b/src/main/locales/locale/af.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Afrikaans</title>
       <bibliomisc role="language">af</bibliomisc>

--- a/src/main/locales/locale/am.xml
+++ b/src/main/locales/locale/am.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Amharic</title>
       <bibliomisc role="language">am</bibliomisc>

--- a/src/main/locales/locale/ar.xml
+++ b/src/main/locales/locale/ar.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Arabic</title>
       <bibliomisc role="language">ar</bibliomisc>

--- a/src/main/locales/locale/as.xml
+++ b/src/main/locales/locale/as.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Assamese</title>
       <bibliomisc role="language">as</bibliomisc>

--- a/src/main/locales/locale/ast.xml
+++ b/src/main/locales/locale/ast.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Asturian</title>
       <bibliomisc role="language">ast</bibliomisc>

--- a/src/main/locales/locale/az.xml
+++ b/src/main/locales/locale/az.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Azerbaijani</title>
       <bibliomisc role="language">az</bibliomisc>

--- a/src/main/locales/locale/bg.xml
+++ b/src/main/locales/locale/bg.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Bulgarian</title>
       <bibliomisc role="language">bg</bibliomisc>

--- a/src/main/locales/locale/bn.xml
+++ b/src/main/locales/locale/bn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Bangla</title>
       <bibliomisc role="language">bn</bibliomisc>

--- a/src/main/locales/locale/bn_in.xml
+++ b/src/main/locales/locale/bn_in.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Indian Bangla</title>
       <bibliomisc role="language">bn_in</bibliomisc>

--- a/src/main/locales/locale/bs.xml
+++ b/src/main/locales/locale/bs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Bosnian</title>
       <bibliomisc role="language">bs</bibliomisc>

--- a/src/main/locales/locale/ca.xml
+++ b/src/main/locales/locale/ca.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Catalan</title>
       <bibliomisc role="language">ca</bibliomisc>

--- a/src/main/locales/locale/cs.xml
+++ b/src/main/locales/locale/cs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Czech</title>
       <bibliomisc role="language">cs</bibliomisc>

--- a/src/main/locales/locale/cy.xml
+++ b/src/main/locales/locale/cy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Welsh</title>
       <bibliomisc role="language">cy</bibliomisc>

--- a/src/main/locales/locale/da.xml
+++ b/src/main/locales/locale/da.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Danish</title>
       <bibliomisc role="language">da</bibliomisc>

--- a/src/main/locales/locale/de.xml
+++ b/src/main/locales/locale/de.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for German</title>
       <bibliomisc role="language">de</bibliomisc>

--- a/src/main/locales/locale/el.xml
+++ b/src/main/locales/locale/el.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Greek</title>
       <bibliomisc role="language">el</bibliomisc>

--- a/src/main/locales/locale/en.xml
+++ b/src/main/locales/locale/en.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for English</title>
       <bibliomisc role="language">en</bibliomisc>

--- a/src/main/locales/locale/eo.xml
+++ b/src/main/locales/locale/eo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Esperanto</title>
       <bibliomisc role="language">eo</bibliomisc>

--- a/src/main/locales/locale/es.xml
+++ b/src/main/locales/locale/es.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Spanish</title>
       <bibliomisc role="language">es</bibliomisc>

--- a/src/main/locales/locale/et.xml
+++ b/src/main/locales/locale/et.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Estonian</title>
       <bibliomisc role="language">et</bibliomisc>

--- a/src/main/locales/locale/eu.xml
+++ b/src/main/locales/locale/eu.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Basque</title>
       <bibliomisc role="language">eu</bibliomisc>

--- a/src/main/locales/locale/fa.xml
+++ b/src/main/locales/locale/fa.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Farsi</title>
       <bibliomisc role="language">fa</bibliomisc>

--- a/src/main/locales/locale/fi.xml
+++ b/src/main/locales/locale/fi.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Finnish</title>
       <bibliomisc role="language">fi</bibliomisc>

--- a/src/main/locales/locale/fr.xml
+++ b/src/main/locales/locale/fr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for French</title>
       <bibliomisc role="language">fr</bibliomisc>

--- a/src/main/locales/locale/ga.xml
+++ b/src/main/locales/locale/ga.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Irish</title>
       <bibliomisc role="language">ga</bibliomisc>

--- a/src/main/locales/locale/gl.xml
+++ b/src/main/locales/locale/gl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Galician</title>
       <bibliomisc role="language">gl</bibliomisc>

--- a/src/main/locales/locale/gu.xml
+++ b/src/main/locales/locale/gu.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Gujarati</title>
       <bibliomisc role="language">gu</bibliomisc>

--- a/src/main/locales/locale/he.xml
+++ b/src/main/locales/locale/he.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Hebrew</title>
       <bibliomisc role="language">he</bibliomisc>

--- a/src/main/locales/locale/hi.xml
+++ b/src/main/locales/locale/hi.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Hindi</title>
       <bibliomisc role="language">hi</bibliomisc>

--- a/src/main/locales/locale/hr.xml
+++ b/src/main/locales/locale/hr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Croatian</title>
       <bibliomisc role="language">hr</bibliomisc>

--- a/src/main/locales/locale/hu.xml
+++ b/src/main/locales/locale/hu.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Hungarian</title>
       <bibliomisc role="language">hu</bibliomisc>

--- a/src/main/locales/locale/id.xml
+++ b/src/main/locales/locale/id.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Indonesian</title>
       <bibliomisc role="language">id</bibliomisc>

--- a/src/main/locales/locale/is.xml
+++ b/src/main/locales/locale/is.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Icelandic</title>
       <bibliomisc role="language">is</bibliomisc>

--- a/src/main/locales/locale/it.xml
+++ b/src/main/locales/locale/it.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Italian</title>
       <bibliomisc role="language">it</bibliomisc>

--- a/src/main/locales/locale/ja.xml
+++ b/src/main/locales/locale/ja.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Japanese</title>
       <bibliomisc role="language">ja</bibliomisc>

--- a/src/main/locales/locale/ka.xml
+++ b/src/main/locales/locale/ka.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Georgian</title>
       <bibliomisc role="language">ka</bibliomisc>

--- a/src/main/locales/locale/kn.xml
+++ b/src/main/locales/locale/kn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Kannada</title>
       <bibliomisc role="language">kn</bibliomisc>

--- a/src/main/locales/locale/ko.xml
+++ b/src/main/locales/locale/ko.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Korean</title>
       <bibliomisc role="language">ko</bibliomisc>

--- a/src/main/locales/locale/ky.xml
+++ b/src/main/locales/locale/ky.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Kirghiz</title>
       <bibliomisc role="language">ky</bibliomisc>

--- a/src/main/locales/locale/la.xml
+++ b/src/main/locales/locale/la.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Latin</title>
       <bibliomisc role="language">la</bibliomisc>

--- a/src/main/locales/locale/lt.xml
+++ b/src/main/locales/locale/lt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Lithuanian</title>
       <bibliomisc role="language">lt</bibliomisc>

--- a/src/main/locales/locale/lv.xml
+++ b/src/main/locales/locale/lv.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Latvian</title>
       <bibliomisc role="language">lv</bibliomisc>

--- a/src/main/locales/locale/ml.xml
+++ b/src/main/locales/locale/ml.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Malayalam</title>
       <bibliomisc role="language">ml</bibliomisc>

--- a/src/main/locales/locale/mn.xml
+++ b/src/main/locales/locale/mn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Mongolian</title>
       <bibliomisc role="language">mn</bibliomisc>

--- a/src/main/locales/locale/mr.xml
+++ b/src/main/locales/locale/mr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Marathi</title>
       <bibliomisc role="language">mr</bibliomisc>

--- a/src/main/locales/locale/nb.xml
+++ b/src/main/locales/locale/nb.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Norwegian Bokmål</title>
       <bibliomisc role="language">nb</bibliomisc>

--- a/src/main/locales/locale/nds.xml
+++ b/src/main/locales/locale/nds.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Low German</title>
       <bibliomisc role="language">nds</bibliomisc>

--- a/src/main/locales/locale/nl.xml
+++ b/src/main/locales/locale/nl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Dutch</title>
       <bibliomisc role="language">nl</bibliomisc>

--- a/src/main/locales/locale/nn.xml
+++ b/src/main/locales/locale/nn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Norwegian Nynorsk</title>
       <bibliomisc role="language">nn</bibliomisc>

--- a/src/main/locales/locale/or.xml
+++ b/src/main/locales/locale/or.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Oriya</title>
       <bibliomisc role="language">or</bibliomisc>

--- a/src/main/locales/locale/pa.xml
+++ b/src/main/locales/locale/pa.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Punjabi</title>
       <bibliomisc role="language">pa</bibliomisc>

--- a/src/main/locales/locale/pl.xml
+++ b/src/main/locales/locale/pl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Polish</title>
       <bibliomisc role="language">pl</bibliomisc>

--- a/src/main/locales/locale/pt.xml
+++ b/src/main/locales/locale/pt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Portuguese</title>
       <bibliomisc role="language">pt</bibliomisc>

--- a/src/main/locales/locale/pt_br.xml
+++ b/src/main/locales/locale/pt_br.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Portuguese (Brazil)</title>
       <bibliomisc role="language">pt_br</bibliomisc>

--- a/src/main/locales/locale/ro.xml
+++ b/src/main/locales/locale/ro.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Romanian</title>
       <bibliomisc role="language">ro</bibliomisc>

--- a/src/main/locales/locale/ru.xml
+++ b/src/main/locales/locale/ru.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Russian</title>
       <bibliomisc role="language">ru</bibliomisc>

--- a/src/main/locales/locale/se.xml
+++ b/src/main/locales/locale/se.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Northern Sami</title>
       <bibliomisc role="language">se</bibliomisc>

--- a/src/main/locales/locale/sk.xml
+++ b/src/main/locales/locale/sk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Slovak</title>
       <bibliomisc role="language">sk</bibliomisc>

--- a/src/main/locales/locale/sl.xml
+++ b/src/main/locales/locale/sl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Slovenian</title>
       <bibliomisc role="language">sl</bibliomisc>

--- a/src/main/locales/locale/sq.xml
+++ b/src/main/locales/locale/sq.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Albanian</title>
       <bibliomisc role="language">sq</bibliomisc>

--- a/src/main/locales/locale/sr.xml
+++ b/src/main/locales/locale/sr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Serbian in Cyrillic script</title>
       <bibliomisc role="language">sr</bibliomisc>

--- a/src/main/locales/locale/sr_Latn.xml
+++ b/src/main/locales/locale/sr_Latn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Serbian in Latin script</title>
       <bibliomisc role="language">sr_latn</bibliomisc>

--- a/src/main/locales/locale/sv.xml
+++ b/src/main/locales/locale/sv.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Swedish</title>
       <bibliomisc role="language">sv</bibliomisc>

--- a/src/main/locales/locale/ta.xml
+++ b/src/main/locales/locale/ta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Tamil</title>
       <bibliomisc role="language">ta</bibliomisc>

--- a/src/main/locales/locale/te.xml
+++ b/src/main/locales/locale/te.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Telugu</title>
       <bibliomisc role="language">te</bibliomisc>

--- a/src/main/locales/locale/th.xml
+++ b/src/main/locales/locale/th.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Thai</title>
       <bibliomisc role="language">th</bibliomisc>

--- a/src/main/locales/locale/tl.xml
+++ b/src/main/locales/locale/tl.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Tagalog</title>
       <bibliomisc role="language">tl</bibliomisc>

--- a/src/main/locales/locale/tr.xml
+++ b/src/main/locales/locale/tr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Turkish</title>
       <bibliomisc role="language">tr</bibliomisc>

--- a/src/main/locales/locale/uk.xml
+++ b/src/main/locales/locale/uk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Ukrainian</title>
       <bibliomisc role="language">uk</bibliomisc>

--- a/src/main/locales/locale/ur.xml
+++ b/src/main/locales/locale/ur.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Urdu</title>
       <bibliomisc role="language">ur</bibliomisc>

--- a/src/main/locales/locale/vi.xml
+++ b/src/main/locales/locale/vi.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Vietnamese</title>
       <bibliomisc role="language">vi</bibliomisc>

--- a/src/main/locales/locale/xh.xml
+++ b/src/main/locales/locale/xh.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Xhosa</title>
       <bibliomisc role="language">xh</bibliomisc>

--- a/src/main/locales/locale/zh.xml
+++ b/src/main/locales/locale/zh.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Chinese</title>
       <bibliomisc role="language">zh</bibliomisc>

--- a/src/main/locales/locale/zh_cn.xml
+++ b/src/main/locales/locale/zh_cn.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Chinese Simplified</title>
       <bibliomisc role="language">zh_cn</bibliomisc>

--- a/src/main/locales/locale/zh_tw.xml
+++ b/src/main/locales/locale/zh_tw.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<article xmlns="http://docbook.org/ns/docbook"
-         xmlns:l="http://docbook.org/ns/docbook/l10n">
+<article xmlns="http://docbook.org/ns/docbook">
    <info>
       <title>Localization file for Chinese (Taiwan)</title>
       <bibliomisc role="language">zh_tw</bibliomisc>


### PR DESCRIPTION
The `src/main/locales/locale/*` files are committed to the repo, even though they are (still) currently generated from the `local-10` forms. In fixing the bug where they had an errant namespace (to fix a bug where something hand changed the indentation of that namespace declaration in the output), I caused them to be different, but failed to commit the changed versions to the repo.

That messed up publication of the web artifacts. So 1.6.2 fixes this bug. It has no technical differences from 1.6.1 in release.

I assume I did this because the intent is eventually for the `locale` files to become the sources and the `locale-10` files to go away.