### PR TITLE
Give up on openssl, use gnupg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           if [ -z "$SAXPASSPHRASE" ]; then
             echo "No secrets available, will run with Saxon-HE"
           else
-            openssl aes-256-cbc -d -k $SAXPASSPHRASE -in tools/saxon.enc | tar zxf -
+            gpg --batch --yes --passphrase $SAXPASSPHRASE -d tools/saxon.enc | tar zxf -
           fi
 
       - run: ./gradlew dependencies


### PR DESCRIPTION
I couldn't sort out how to make openssl continue working. Using the suggested `-pbkdf2` and `-iter` options to encrypt didn't produce a file that I could decrypt. Even on the system that did the encryption. ¯\_(ツ)_/¯