### PR TITLE
Don't call resolve-uri if it isn't necessary

### DIFF
--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -258,6 +258,9 @@
           select="resolve-uri($node/@db-chunk,
                               fp:chunk-output-filename($pchunk))"/>
     </xsl:when>
+    <xsl:when test="not($v:chunk)">
+      <xsl:sequence select="base-uri(root($node)/*)"/>
+    </xsl:when>
     <xsl:otherwise>
       <xsl:sequence
           select="resolve-uri($node/@db-chunk,
@@ -308,7 +311,9 @@
   <xsl:param name="href" as="xs:string" required="yes"/>
 
   <xsl:variable name="absuri"
-                select="resolve-uri($href, $rootbaseuri)"/>
+                select="if ($v:chunk)
+                        then resolve-uri($href, $rootbaseuri)
+                        else $rootbaseuri"/>
 
   <xsl:variable name="rchunk"
                 select="fp:trim-common-prefix($chunkbaseuri, $absuri)"/>
@@ -536,7 +541,15 @@
   <xsl:param name="node" as="element()"/>
   <!-- Saxonica bug #4632 -->
   <xsl:sequence select="base-uri(root($node)/*)[. = '-no match-']"/>
-  <xsl:sequence select="resolve-uri($chunk-output-base-uri, base-uri(root($node)/*))"/>
+  <xsl:choose>
+    <xsl:when test="not($v:chunk)">
+      <xsl:sequence select="base-uri(root($node)/*)"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="resolve-uri($chunk-output-base-uri,
+                                        base-uri(root($node)/*))"/>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:function>
 
 <!-- ============================================================ -->

--- a/src/test/java/org/docbook/xsltng/GitHubIssues.java
+++ b/src/test/java/org/docbook/xsltng/GitHubIssues.java
@@ -1,0 +1,41 @@
+package org.docbook.xsltng;
+
+import net.sf.saxon.s9api.*;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+
+import javax.xml.transform.sax.SAXSource;
+import java.io.File;
+import java.io.FileInputStream;
+
+import static org.junit.Assert.fail;
+
+public class GitHubIssues {
+    @Test
+    public void test0152() {
+        // If the input document isn't being chunked, and it has a non-hierarchical base URI,
+        // make sure we don't trip up somewhere attempting to resolve-uri.
+        try {
+            Processor processor = new Processor(false);
+
+            FileInputStream stream = new FileInputStream(new File("src/test/resources/issues/0152/input.xml"));
+            InputSource source = new InputSource(stream);
+            source.setSystemId("urn:foo:bar");
+
+            XdmDestination destination = new XdmDestination();
+
+            XsltCompiler compiler = processor.newXsltCompiler();
+            XsltExecutable exec = compiler.compile(new SAXSource(new InputSource("src/test/resources/issues/0152/style.xsl")));
+            Xslt30Transformer xform = exec.load30();
+            xform.applyTemplates(new SAXSource(source), destination);
+
+            String s = destination.getXdmNode().toString();
+            Assert.assertTrue(s.startsWith("<html "));
+
+            Assert.assertNull(destination.getBaseURI());
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+}

--- a/src/test/resources/issues/0152/catalog.xml
+++ b/src/test/resources/issues/0152/catalog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+
+  <system systemId="urn:foo:bar"
+       uri="input.xml"/>
+
+</catalog>

--- a/src/test/resources/issues/0152/input.xml
+++ b/src/test/resources/issues/0152/input.xml
@@ -1,0 +1,4 @@
+<article xmlns="http://docbook.org/ns/docbook">
+<title>Some title</title>
+<para>This is my article.</para>
+</article>

--- a/src/test/resources/issues/0152/style.xsl
+++ b/src/test/resources/issues/0152/style.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                exclude-result-prefixes="xs"
+                version="3.0">
+
+<xsl:import href="../../../../../build/xslt/docbook.xsl"/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Fix #152 

The `cleanup-chunk` mode is used even when chunking isn't enabled. (A non-chunked document still consists of a single chunk and parts of the presentation are cleaned up even for that single chunk.) Part of cleanup up chunks is working out relative base URIs for the parts. If there isn't actually any chunking going on, this will ultimately have no effect, *but* if the base URI of the input document has a non-hierarchical URI (such as `urn:foo:bar`), then the attempted resolution will raise an error.

The workaround implemented here is that if chunking isn't being used, we just return the base URI of the input document as the resolved URI without attempting to resolve it. This doesn't make any difference to the result, since we aren't chunking, but it avoids raising the exception.
