### PR TITLE
Fix verbatim continuations

### DIFF
--- a/src/main/xslt/modules/verbatim.xsl
+++ b/src/main/xslt/modules/verbatim.xsl
@@ -300,7 +300,8 @@
     </xsl:call-template>
   </xsl:variable>
 
-  <xsl:variable name="no-code" select="self::db:address or self::db:literallayout"/>
+  <xsl:variable name="no-code"
+                select="self::db:address or self::db:literallayout"/>
 
   <xsl:variable name="starting-line-number" as="xs:integer">
     <xsl:choose>
@@ -309,7 +310,7 @@
       </xsl:when>
       <xsl:when test="@continuation = 'continues'">
         <xsl:variable name="name" select="node-name(.)"/>
-        <xsl:variable name="prec" select="preceding::*[node-name(.) = $name]"/>
+        <xsl:variable name="prec" select="preceding::*[node-name(.) = $name][1]"/>
         <xsl:choose>
           <xsl:when test="empty($prec)">
             <xsl:sequence select="1"/>

--- a/src/test/resources/expected/screen.002.html
+++ b/src/test/resources/expected/screen.002.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" class="no-js"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><script>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script><title>Article wrapper</title><meta name="viewport" content="width=device-width, initial-scale=1.0"/><link href="https://purl.org/dc/elements/1.1/" rel="schema.dc"/><meta name="dc.modified" content="2022-07-21T06:51:32Z"/><meta name="generator" content="DocBook xslTNG version 1.7.1 / 2d69b23a / SAXON HE 11.3"/><link href="./css/docbook.css" rel="stylesheet"/><link href="./css/docbook-screen.css" rel="stylesheet"/></head><body class="home"><nav class="top"></nav><main><article class="article"><header><h1>Article wrapper</h1></header><p>This is a screen.</p><div class="pre-wrap" db-startinglinenumber="1" db-numberoflines="5"><pre class="long numbered screen verbatim verblines"><span class="line" db-line="1"><span class="ln">1</span><span class="ld"><code>Code 1</code></span></span>
+<span class="line" db-line="2"><span class="ln"></span><span class="ld"><code>Code 2</code></span></span>
+<span class="line" db-line="3"><span class="ln"></span><span class="ld"><code>Code 3</code></span></span>
+<span class="line" db-line="4"><span class="ln"></span><span class="ld"><code>Code 4</code></span></span>
+<span class="line" db-line="5"><span class="ln">5</span><span class="ld"><code>Code 5</code></span></span>
+</pre></div><p>So is this.</p><div class="pre-wrap" db-startinglinenumber="1" db-numberoflines="5"><pre class="long numbered screen verbatim verblines"><span class="line" db-line="1"><span class="ln">1</span><span class="ld"><code>Code 1</code></span></span>
+<span class="line" db-line="2"><span class="ln"></span><span class="ld"><code>Code 2</code></span></span>
+<span class="line" db-line="3"><span class="ln"></span><span class="ld"><code>Code 3</code></span></span>
+<span class="line" db-line="4"><span class="ln"></span><span class="ld"><code>Code 4</code></span></span>
+<span class="line" db-line="5"><span class="ln">5</span><span class="ld"><code>Code 5</code></span></span>
+</pre></div><p>The next screen is a continuation of the previous.</p><div class="pre-wrap" db-startinglinenumber="6" db-numberoflines="5"><pre class="long numbered screen verbatim verblines"><span class="line" db-line="1"><span class="ln">6</span><span class="ld"><code>Code 6</code></span></span>
+<span class="line" db-line="2"><span class="ln"></span><span class="ld"><code>Code 7</code></span></span>
+<span class="line" db-line="3"><span class="ln"></span><span class="ld"><code>Code 8</code></span></span>
+<span class="line" db-line="4"><span class="ln"></span><span class="ld"><code>Code 9</code></span></span>
+<span class="line" db-line="5"><span class="ln">10</span><span class="ld"><code>Code 10</code></span></span>
+</pre></div></article></main><nav class="bottom"></nav></body></html>

--- a/src/test/resources/xml/screen.002.xml
+++ b/src/test/resources/xml/screen.002.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Article wrapper</title>
+
+<para>This is a screen.</para>
+
+<screen>Code 1
+Code 2
+Code 3
+Code 4
+Code 5
+</screen>
+
+<para>So is this.</para>
+
+<screen>Code 1
+Code 2
+Code 3
+Code 4
+Code 5
+</screen>
+
+<para>The next screen is a continuation of the previous.</para>
+
+<screen continuation="continues">Code 6
+Code 7
+Code 8
+Code 9
+Code 10
+</screen>
+
+</article>


### PR DESCRIPTION
If a continuing verbatim environment was preceded by two or more environments of the same type, the stylesheets would fail.

Fix #156 
