### PR TITLE
Fix guide

### DIFF
--- a/src/guide/xsl/guide.xsl
+++ b/src/guide/xsl/guide.xsl
@@ -6,7 +6,7 @@
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:t="http://docbook.org/ns/docbook/templates"
                 xmlns:v="http://docbook.org/ns/docbook/variables"
-                xmlns="http://www.w3.org/1999/HTML"
+                xmlns="http://www.w3.org/1999/xhtml"
                 exclude-result-prefixes="a db f m t v"
                 version="3.0">
 

--- a/src/guide/xsl/print.xsl
+++ b/src/guide/xsl/print.xsl
@@ -4,15 +4,16 @@
                 xmlns:db="http://docbook.org/ns/docbook"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fg="http://docbook.org/ns/guide/functions"
+                xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
-                xmlns:mp="http://docbook.org/ns/docbook/modes/private"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
                 xmlns:mg="http://docbook.org/ns/guide/modes"
+                xmlns:mp="http://docbook.org/ns/docbook/modes/private"
                 xmlns:t="http://docbook.org/ns/docbook/templates"
                 xmlns:tg="http://docbook.org/ns/guide/templates"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
-                exclude-result-prefixes="a db f fg m mp map mg t tg xs"
+                exclude-result-prefixes="#all"
                 version="3.0">
 
 <xsl:import href="guide.xsl"/>
@@ -37,9 +38,9 @@
 <xsl:template match="db:refnamediv" mode="m:docbook">
   <!-- The guide marks refname elements as display:none which means
        that the IDs they have don't turn up as targets. Force (empty)
-       div elements into the output to be link targets. -->
+       a elements into the output to be link targets. -->
   <xsl:for-each select="db:refname[@xml:id]">
-    <div id="{@xml:id}"/>
+    <a id="{@xml:id}"/>
   </xsl:for-each>
   <xsl:next-match/>
 </xsl:template>
@@ -49,6 +50,32 @@
     <xsl:apply-templates select="@* except @xml:id"/>
   </xsl:variable>
   <xsl:sequence select="f:attributes(., $attr)"/>
+</xsl:template>
+
+<!-- Find the header for the book cover page and move its embedded
+     revhistory out of the header. -->
+<xsl:template match="h:header[h:div[contains-token(@class, 'cover')]]"
+              mode="m:chunk-cleanup">
+  <xsl:variable name="header" as="element(h:header)">
+    <xsl:next-match/>
+  </xsl:variable>
+  <xsl:apply-templates select="$header" mode="mp:norevhistory"/>
+  <xsl:copy-of select="$header//h:div[contains-token(@class, 'revhistory')]"/>
+</xsl:template>
+
+<xsl:template match="*" mode="mp:norevhistory">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()" mode="mp:norevhistory"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="h:div[contains-token(@class, 'revhistory')]"
+              mode="mp:norevhistory">
+</xsl:template>
+
+<xsl:template match="text()|comment()|processing-instruction()|attribute()"
+              mode="mp:norevhistory">
+  <xsl:copy/>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR fixes a couple of issues with the reference guide:

1. There was a typo in a namespace URI that resulted in extra namespace declarations in the HTML
2. The revision history printed poorly in the PDF guide

Thanks also to @tgraham-antenna for typo fixes in the preceding PRs!