### PR TITLE
Prepare to release 1.9.1

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -87,8 +87,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
-          draft: true
-          prerelease: true
+          draft: false
+          prerelease: false
           fail_on_unmatched_files: true
           files: |
             build/distributions/docbook-xslTNG-${{ env.CI_TAG }}.zip

--- a/build.gradle
+++ b/build.gradle
@@ -1444,7 +1444,7 @@ task zipDist(type: Zip, dependsOn: ['zipStage']) {
 
 // ============================================================
 
-task dist(dependsOn: ['requirePassingTests', 'zipDist', 'website']) {
+task dist(dependsOn: ['requirePassingTests', 'releaseArtifacts', 'zipDist', 'website']) {
   doLast {
     println("Built dist for ${xslTNGtitle} version ${xslTNGversion}")
   }

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,7 +2,7 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '1.9.0'
+  xslTNGversion = '1.9.1'
   guideVersion = '1.9.1'
 
   docbookVersion = '5.2CR2'


### PR DESCRIPTION
1. Fixed `build.gradle` to make a release directory
2. Publish the release on tagged commits
3. Push to CDN on tagged commits

I've now tested this on my own repos and I believe it will all work correctly...