### PR TITLE
Update the workflow to publish to 'current'

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -73,7 +73,7 @@ jobs:
           branch: gh-pages
           target-folder: /
 
-      - name: Deploy tagged release to CDN
+      - name: Deploy tagged release to CDN as ${{ env.CI_TAG }}
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -82,6 +82,16 @@ jobs:
           repository-name: ${{ github.repository_owner}}/cdn
           branch: master
           target-folder: /release/xsltng/${{ env.CI_TAG }}
+
+      - name: Deploy tagged release to CDN as current
+        if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/release
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository-name: ${{ github.repository_owner}}/cdn
+          branch: master
+          target-folder: /release/xsltng/current
 
       - name: Publish release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This change has no effect on the stylesheets, but should update both the versioned and `current` folders on CDN when tagged releases are published.