### PR TITLE
Hide horizontal scrollbar from verbatim elements when it is not needed

### DIFF
--- a/src/main/web/css/docbook.css
+++ b/src/main/web/css/docbook.css
@@ -844,7 +844,7 @@ th.char {
 /* ============================================================ */
 
 .pre-wrap {
-    overflow-x: scroll;
+    overflow-x: auto;
     margin-top: 1em;
     margin-bottom: 1em;
 }


### PR DESCRIPTION
The current version always shows horizontal scrollbars for verbatim elements. This change makes them optional to improve visual appearance and to remove unnecessary clutter when the elements are completely visible.