### PR TITLE
Improved docs

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.1'
-  guideVersion = '2.0.1'
+  xslTNGversion = '2.0.2'
+  guideVersion = '2.0.2'
 
   docbookVersion = '5.2CR4'
   publishersVersion = '5.2CR4'

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -738,6 +738,13 @@ chunked results (see <xref linkend="chunking"/>), this parameter has no effect.<
 value for this parameter. If the extension isn’t available, you must
 provide a value for this parameter.
 </para>
+<para>Note: if you’re using the stylesheets from Maven, the <code>static-base-uri()</code>
+will be something like <replaceable>https://cdn.docbook.org/release/…</replaceable>
+and resolving the current working directory against that won’t be useful. It’s
+better in those cases to specify the parameter explicitly with a <code>file:</code>
+URI. (And note that it may need to be a <code>file:/path</code> URI, not a 
+<code>file:///path</code> URI, in order to match correctly.)
+</para>
 </refsection>
 </refentry>
 

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -153,9 +153,9 @@
      get normalized because later on we're going to want to compare
      the prefix of this base URI with the prefix of another URI. -->
 <xsl:variable name="vp:chunk-output-base-uri" as="xs:anyURI?"
-              select="if (not($v:chunk))
-                      then ()
-                      else resolve-uri($chunk-output-base-uri, static-base-uri())"/>
+              select="if ($v:chunk)
+                      then resolve-uri($chunk-output-base-uri, static-base-uri())
+                      else ()"/>
 
 <!-- I tinkered a bit to find images that would display across
      a variety of devices. YMMV. -->


### PR DESCRIPTION
I discovered a weird consequence of using DocBook xslTNG from Maven and the way `chunk-output-base-uri` is used. Possibly needs a better/different solution, but in the meantime, I've documented the consequence.