### PR TITLE
Preserve guide/index.html

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -69,8 +69,7 @@ jobs:
           mkdir /tmp/guide
           rsync -var guide/ /tmp/guide/
           rm -f /tmp/guide/*.html /tmp/guide/validated.xml
-          rm -rf /tmp/guide/css /tmp/guide/js
-          ls -l /tmp/guide/
+          cp guide/index.html /tmp
 
       - name: Checkout the main branch
         uses: actions/checkout@v3
@@ -91,7 +90,11 @@ jobs:
         run: cd build/website && tar zxf /tmp/save-epub-pdf.tar.gz
 
       - name: Restore previous version(s) of the guide
-        run: rsync -var /tmp/guide/ build/website/guide/
+        run: |
+          rsync -var /tmp/guide/ build/website/guide/
+          if [ ! -f build/website/guide/index.html ]; then \
+            mv /tmp/index.html build/website/guide/; \
+          fi
 
       - name: Deploy main to gh-pages
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' }}


### PR DESCRIPTION
If the build is making a prerelease version of the guide, it *doesn't* create the index, but if it's making a "production" release, it does.