### PR TITLE
A number of small bug fixes and improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2130,7 +2130,7 @@ task xformtest(type: SaxonXsltTask, dependsOn: ['makeXslt']) {
   pluginConfiguration "docbook"
   input "${projectDir}/test.xml"
   stylesheet "${buildDir}/xslt/docbook.xsl"
-  output "${projectDir}/test.html"
+  output "${buildDir}/actual/test.html"
   parameters(
   )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,6 @@ dependencies {
     [group: 'org.relaxng', name: 'trang', version: "20181222" ],
     [group: 'org.xmlresolver', name: 'xmlresolver', version: xmlresolverVersion],
     [group: 'com.nwalsh', name: 'sinclude', version: sincludeVersion ],
-    [group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion ],
     files("${projectDir}/buildSrc/build/classes/java/main"),
     files(saxonLicenseDir)
   )

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.3'
-  guideVersion = '2.0.3'
+  xslTNGversion = '2.0.4'
+  guideVersion = '2.0.4'
   guidePrerelease = true
 
   docbookVersion = '5.2CR4'
@@ -17,7 +17,6 @@ ext {
 
   metadataExtractorVersion = '2.18.0'
   jingVersion = '20220510'
-  xmlresolverVersion = '4.6.0'
+  xmlresolverVersion = '4.6.4'
   sincludeVersion = '4.2.1'
-  slf4jVersion = '1.7.36'
 }

--- a/src/main/scss/media-all.scss
+++ b/src/main/scss/media-all.scss
@@ -276,6 +276,12 @@ span.remark {
     box-shadow: var(--keycap-box-shadow);
 }
 
+.keycombo {
+    .keycap + .keycap {
+        margin-left: 0.4em;
+    }
+}
+
 code {
     font-family: var(--mono-family);
     background-color: var(--verbatim-odd-background-color);

--- a/src/main/xslt/modules/inlines.xsl
+++ b/src/main/xslt/modules/inlines.xsl
@@ -369,6 +369,9 @@
     <xsl:when test="exists(node())">
       <xsl:call-template name="t:inline"/>
     </xsl:when>
+    <xsl:when test="empty($lookup)">
+      <xsl:message select="'Ignoring keycap without function attribute or content'"/>
+    </xsl:when>
     <xsl:when test="exists(fp:localization-template(., 'keycap'))">
       <xsl:call-template name="t:inline">
         <xsl:with-param name="content" as="item()*">

--- a/src/main/xslt/modules/objects.xsl
+++ b/src/main/xslt/modules/objects.xsl
@@ -91,7 +91,9 @@
         <xsl:variable name="alternatives"
                       select="count(db:audiodata|db:imagedata|db:videodata)"/>
         <xsl:variable name="selected-alternatives"
-                      select="array:size($info?datas)"/>
+                      select="if (exists($info) and map:contains($info, 'datas'))
+                              then array:size($info?datas)
+                              else 0"/>
 
         <xsl:choose>
           <xsl:when test="./self::db:textobject and not(db:phrase)">

--- a/src/main/xslt/modules/titlepage.xsl
+++ b/src/main/xslt/modules/titlepage.xsl
@@ -5,11 +5,12 @@
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:t="http://docbook.org/ns/docbook/l10n/title"
+                xmlns:v="http://docbook.org/ns/docbook/variables"
                 xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
                 default-mode="m:docbook"
-                exclude-result-prefixes="db f fp m t vp xs"
+                exclude-result-prefixes="#all"
                 version="3.0">
 
 <xsl:template match="db:title" mode="m:titlepage">
@@ -71,8 +72,10 @@
 </xsl:template>
 
 <xsl:template match="*" mode="m:titlepage">
-  <xsl:message select="'No titlepage template for: ' || node-name(.)"/>
-  <xsl:apply-templates select="node()"/>
+  <xsl:if test="'templates' = $v:debug">
+    <xsl:message select="'No titlepage template for: ' || node-name(.)"/>
+  </xsl:if>
+  <xsl:apply-templates select="."/>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
1. Use CSS to put a little space between adjacent `keycap` elements in a `keycombo`. Unfortunately, the semantics of the CSS "adjacent sibling" connector are that it ignores text. That means this technique can't be applied more generally to adjacent keycaps.
2. Added a better error message for an empty, `@function`less `keycap`.
3. Handled the case where a `mediaobject` has no usable media. This can happen, for example, if the object contains only inline `textobject`s
4. Process unexpected elements in titlepage templates in the default, `m:docbook`, mode rather than only processing their children.
5. Removed the warning message about unexpected elements in titlepage templates. To restore it, use `templates` in `$debug`.
6. Updated versions and build dependencies.