### PR TITLE
Fix EPUB and some odds and ends

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,8 +351,7 @@ def pkglist = ["net.sf.saxon:Saxon-HE:${saxonVersion}",
                "com.drewnoakes:metadata-extractor:${metadataExtractorVersion}",
                "org.relaxng:jing:${jingVersion}",
                "org.xmlresolver:xmlresolver:${xmlresolverVersion}",
-               "com.nwalsh:sinclude:${sincludeVersion}",
-               "org.slf4j:slf4j-simple:${slf4jVersion}"]
+               "com.nwalsh:sinclude:${sincludeVersion}"]
 
 task copyBin(type: Copy) {
   def packages = ""

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.4'
-  guideVersion = '2.0.4'
+  xslTNGversion = '2.0.3'
+  guideVersion = '2.0.3'
   guidePrerelease = true
 
   docbookVersion = '5.2CR4'

--- a/src/guide/resources/css/guide-epub.css
+++ b/src/guide/resources/css/guide-epub.css
@@ -105,3 +105,16 @@
     page-break-after: avoid;
     display: inherit;
 }
+
+nav ol.toc {
+    list-style: none;
+}
+
+.toc .toc {
+    margin-top: 0;
+}
+
+nav ol.toc a,
+nav ol.toc a:visited {
+    color: inherit;
+}

--- a/src/guide/xml/changelog.xml
+++ b/src/guide/xml/changelog.xml
@@ -3,11 +3,28 @@
 <?db revhistory-style="list"?>
 <revision>
 <revnumber>2.0.3</revnumber>
-<date>2023-01-06</date>
+<date>2023-01-21</date>
 <revdescription>
 <itemizedlist>
 <listitem>
 <para>Removed <keycap>↑</keycap> from <parameter>chunk-nav</parameter>.</para>
+</listitem>
+<listitem>
+<para>Support media objects that have no media (e.g., a media object that contains
+only inline text objects).</para>
+</listitem>
+<listitem>
+<para>Process unexected elements in titlepage templates in the normal way; removed
+the warning message associated with them. Added it back by putting
+<code>templates</code> in <parameter>debug</parameter>.</para>
+</listitem>
+<listitem>
+<para>Improved presentation of multiple <tag>keycap</tag> elements in a 
+<tag>keycombo</tag>.</para>
+</listitem>
+<listitem>
+<para>Added table-of-contents to the linear flow of EPUBs. This fixes an
+<application>epubcheck</application> 3.3 error. Fixed the CSS for the ToC.</para>
 </listitem>
 </itemizedlist>
 </revdescription>

--- a/src/main/xslt/epub.xsl
+++ b/src/main/xslt/epub.xsl
@@ -116,6 +116,7 @@
         <itemref idref="cover" linear="no"/>
         -->
         <itemref idref="titlepage" linear="yes"/>
+        <itemref idref="toc" linear="yes"/>
         <!--
         <itemref idref="brief-toc" linear="yes"/>
         -->
@@ -127,7 +128,6 @@
         <!--
         <itemref idref="copyright" linear="yes"/>
         -->
-        <itemref idref="toc" linear="no"/>
       </spine>
     </package>
   </xsl:result-document>

--- a/src/main/xslt/modules/epub-chunk.xsl
+++ b/src/main/xslt/modules/epub-chunk.xsl
@@ -50,7 +50,14 @@
       <xsl:copy-of select="$toc/h:html/h:head"/>
       <body>
         <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
-          <xsl:copy-of select="($toc//h:ol[contains-token(@class, 'toc')])[1]"/>
+          <xsl:variable
+              name="lot"
+              select="($toc//h:div[contains-token(@class, 'list-of-titles')])[1]"/>
+          <h1>
+            <xsl:sequence
+                select="($lot/h:div/h:div[contains-token(@class, 'title')])[1]/node()"/>
+          </h1>
+          <xsl:sequence select="($lot//h:ol[contains-token(@class, 'toc')])[1]"/>
         </nav>
       </body>
     </xsl:copy>


### PR DESCRIPTION
Turns out EPUB 3.3 checks don't like to have the ToC unlinked from the document. Not sure what the right answer is, but in the short term, I've simply linked it back into the beginning of the document.

I also fixed some EPUB CSS, removed a broken slf4j reference from the build script, updated the change log, and rolled the release version back to 2.0.3 because that release was never made.
