### PR TITLE
Fix ext:cwd() so it returns an absolute URI

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,5 +1,6 @@
 name: build-docbook
 on: push
+
 jobs:
   check_branch:
     runs-on: ubuntu-latest
@@ -36,6 +37,7 @@ jobs:
     needs: check_branch
     env:
       HAVE_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN != '' }}
+      HAVE_GPGKEYURI: ${{ secrets.ACCESS_TOKEN != '' && secrets.GPGKEYURI != '' }}
       HAVE_SAXON_EE: ${{ secrets.SAXON_PASSPHRASE != '' }}
       CIWORKFLOW: yes
       CI_SHA1: ${{ github.sha }}
@@ -134,6 +136,18 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             build/distributions/docbook-xslTNG-${{ env.CI_TAG }}.zip
+
+      - name: Publish to Sonatype
+        if: ${{ env.HAVE_GPGKEYURI == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
+        run: |
+          curl -s -o secret.gpg ${{ secrets.GPGKEYURI }}
+          ./gradlew -PsonatypeUsername=${{ secrets.SONATYPEUSER }} \
+                  -PsonatypePassword="${{ secrets.SONATYPEPASS }}" \
+                  -Psigning.keyId="${{ secrets.SIGNKEY }}" \
+                  -Psigning.password="${{ secrets.SIGNPSW }}" \
+                  -Psigning.secretKeyRingFile=./secret.gpg \
+                  publish
+          rm -f secret.gpg
 
       - name: Checkout the CDN
         uses: actions/checkout@v3

--- a/buildSrc/src/main/java/org/docbook/xsltng/extensions/Cwd.java
+++ b/buildSrc/src/main/java/org/docbook/xsltng/extensions/Cwd.java
@@ -16,7 +16,7 @@ import net.sf.saxon.value.SequenceType;
  * <a href="http://saxonica.com/">Saxon</a>
  * extension to return the current working directory (the user.dir system property).
  *
- * <p>Copyright © 2011-2020 Norman Walsh.
+ * <p>Copyright © 2011-2023 Norman Walsh.
  *
  * @author Norman Walsh
  * <a href="mailto:ndw@nwalsh.com">ndw@nwalsh.com</a>
@@ -61,7 +61,16 @@ public class Cwd extends ExtensionFunctionDefinition {
             if (!dir.endsWith("/")) {
                 dir += "/";
             }
-            return new AnyURIValue(dir);
+
+            // 21 Jan 2023, make this a file: URI. Previously, this was left as just a path
+            // and it was made absolute against the static base uri. But that doesn't work
+            // correctly if the static base URI is, for example https://cdn.docbook.org/...
+            if (dir.startsWith("/")) {
+                return new AnyURIValue("file:" + dir);
+            } else {
+                // Windows, for example, where dir might be C:\...
+                return new AnyURIValue("file:/" + dir);
+            }
         }
     }
 }

--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.3'
-  guideVersion = '2.0.3'
+  xslTNGversion = '2.0.4'
+  guideVersion = '2.0.4'
   guidePrerelease = true
 
   docbookVersion = '5.2CR4'

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -736,9 +736,7 @@ support keyboard navigation.</para>
   </xsl:when>
   <xsl:when use-when="function-available('ext:cwd')"
             test="true()">
-    <xsl:message select="'Default output base uri:',
-                         resolve-uri(ext:cwd(), static-base-uri())"/>
-    <xsl:sequence select="resolve-uri(ext:cwd(), static-base-uri())"/>
+    <xsl:sequence select="ext:cwd()"/>
   </xsl:when>
   <xsl:otherwise>
     <xsl:message terminate="yes"
@@ -2381,7 +2379,7 @@ format.
       <type>xs:string</type>
       <varname>mediaobject-input-base-uri</varname>
       <initializer><xsl:sequence use-when="function-available('ext:cwd')"
-              select="resolve-uri(ext:cwd(), static-base-uri())"/>
+              select="ext:cwd()"/>
 <xsl:sequence use-when="not(function-available('ext:cwd'))"
               select="''"/></initializer>
     </fieldsynopsis>

--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -172,8 +172,7 @@
   <xsl:variable name="starting-base-uri" as="xs:string">
     <xsl:choose>
       <xsl:when test="true()" use-when="function-available('ext:cwd')">
-        <xsl:sequence select="resolve-uri(base-uri(.),
-                                          resolve-uri(ext:cwd(), static-base-uri()))"/>
+        <xsl:sequence select="resolve-uri(base-uri(.), ext:cwd())"/>
       </xsl:when>
       <xsl:when test="true()">
         <xsl:sequence select="resolve-uri(base-uri(.), static-base-uri())"/>

--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -9,10 +9,11 @@
                 xmlns:mp="http://docbook.org/ns/docbook/modes/private"
                 xmlns:t="http://docbook.org/ns/docbook/templates"
                 xmlns:v="http://docbook.org/ns/docbook/variables"
+                xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
                 default-mode="m:chunk-cleanup"
-                exclude-result-prefixes="db dbe f fp h m mp t v xs"
+                exclude-result-prefixes="#all"
                 version="3.0">
 
 <xsl:key name="hid" match="*" use="@id"/>
@@ -276,8 +277,7 @@
       <xsl:otherwise>
         <xsl:sequence
             select="resolve-uri($node/@db-chunk,
-                                resolve-uri($chunk-output-base-uri,
-                                            base-uri(root($node)/*)))"/>
+                                $vp:chunk-output-base-uri)"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
@@ -566,8 +566,7 @@
       <xsl:sequence select="base-uri(root($node)/*)"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:sequence select="resolve-uri($chunk-output-base-uri,
-                                        base-uri(root($node)/*))"/>
+      <xsl:sequence select="$vp:chunk-output-base-uri"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>

--- a/src/main/xslt/modules/chunk-output.xsl
+++ b/src/main/xslt/modules/chunk-output.xsl
@@ -211,7 +211,7 @@
 
 <xsl:function name="fp:resolve-persistent-toc" cache="yes" as="element(h:div)">
   <xsl:param name="toc" as="element(h:div)"/>
-  <xsl:apply-templates select="$toc" mode="mp:copy-patch-toc2"/>
+  <xsl:apply-templates select="$toc" mode="mp:copy-patch-toc"/>
 </xsl:function>
 
 <xsl:template match="element()">
@@ -227,121 +227,9 @@
 
 <!-- ============================================================ -->
 
+<xsl:mode name="mp:copy-patch-toc" on-no-match="shallow-copy"/>
+
 <xsl:template match="h:a[@href]" mode="mp:copy-patch-toc">
-  <xsl:param name="source" as="element()"/>
-  <xsl:param name="prefix" as="xs:string"/>
-
-  <xsl:variable name="href" as="xs:string">
-    <xsl:choose>
-      <xsl:when test="starts-with(@href, '#')">
-        <xsl:sequence select="fp:patch-toc-href($source, @href/string())"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="@href/string()"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
-
-  <xsl:copy>
-    <xsl:copy-of select="@* except @href"/>
-    <xsl:attribute name="href" select="concat($prefix, $href)"/>
-    <xsl:apply-templates select="node()" mode="mp:copy-patch-toc">
-      <xsl:with-param name="source" select="$source"/>
-      <xsl:with-param name="prefix" select="$prefix"/>
-    </xsl:apply-templates>
-  </xsl:copy>
-</xsl:template>
-
-<xsl:template match="h:ul" mode="mp:copy-patch-toc"
-              priority="10">
-  <xsl:param name="title" select="()"/>
-  <xsl:param name="source" as="element()"/>
-  <xsl:param name="prefix" as="xs:string"/>
-  <xsl:copy>
-    <xsl:apply-templates select="@* except @class" mode="mp:copy-patch-toc">
-      <xsl:with-param name="source" select="$source"/>
-      <xsl:with-param name="prefix" select="$prefix"/>
-    </xsl:apply-templates>
-    <xsl:choose>
-      <xsl:when test="exists($title)">
-        <xsl:attribute name="class" select="@class || ' nav-title'"/>
-        <li class="nav-title">
-          <xsl:sequence select="$title"/>
-        </li>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:attribute name="class" select="@class"/>
-      </xsl:otherwise>
-    </xsl:choose>
-    <xsl:apply-templates select="node()" mode="mp:copy-patch-toc">
-      <xsl:with-param name="source" select="$source"/>
-      <xsl:with-param name="prefix" select="$prefix"/>
-    </xsl:apply-templates>
-  </xsl:copy>
-</xsl:template>
-
-<xsl:template match="element()" mode="mp:copy-patch-toc">
-  <xsl:param name="source" as="element()"/>
-  <xsl:param name="prefix" as="xs:string"/>
-  <xsl:copy>
-    <xsl:apply-templates select="@*,node()" mode="mp:copy-patch-toc">
-      <xsl:with-param name="source" select="$source"/>
-      <xsl:with-param name="prefix" select="$prefix"/>
-    </xsl:apply-templates>
-  </xsl:copy>
-</xsl:template>
-
-<xsl:template match="attribute()|text()|comment()|processing-instruction()"
-              mode="mp:copy-patch-toc">
-  <xsl:param name="source" as="element()"/>
-  <xsl:param name="prefix" as="xs:string"/>
-  <xsl:copy/>
-</xsl:template>
-
-<xsl:function name="fp:patch-toc-href">
-  <xsl:param name="here" as="element()"/>
-  <xsl:param name="href" as="xs:string"/>
-
-  <xsl:variable name="id" select="substring-after($href, '#')"/>
-  <xsl:variable name="target" select="key('hid', $id, root($here))"/>
-  <xsl:variable name="pchunk"
-                select="($here/root()//*[@db-chunk])[1]"/>
-  <xsl:variable name="tchunk"
-                select="($target/ancestor-or-self::*[@db-chunk])[last()]"/>
-
-  <xsl:choose>
-    <xsl:when test="empty($target)">
-      <!-- this will already have been reported -->
-      <xsl:sequence select="$href"/>
-    </xsl:when>
-    <xsl:when test="$pchunk is $tchunk">
-      <xsl:if test="'intra-chunk-refs' = $v:debug">
-        <xsl:message select="'ToC link:', $href, 'in same chunk as target'"/>
-      </xsl:if>
-      <xsl:sequence select="$href"/>
-    </xsl:when>
-    <xsl:when test="$tchunk/@id = $id">
-      <xsl:if test="'intra-chunk-refs' = $v:debug">
-        <xsl:message select="'ToC link:', $href,
-                             'to root of', $tchunk/@db-chunk/string()"/>
-      </xsl:if>
-      <xsl:sequence select="fp:relative-link($pchunk, $tchunk)"/>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:if test="'intra-chunk-refs' = $v:debug">
-        <xsl:message select="'ToC link:', $href,
-                             'in chunk', $tchunk/@db-chunk/string()"/>
-      </xsl:if>
-      <xsl:sequence select="fp:relative-link($pchunk, $tchunk)||$href"/>
-    </xsl:otherwise>
-  </xsl:choose>
-</xsl:function>
-
-<!-- ============================================================ -->
-
-<xsl:mode name="mp:copy-patch-toc2" on-no-match="shallow-copy"/>
-
-<xsl:template match="h:a[@href]" mode="mp:copy-patch-toc2">
   <xsl:variable name="href" as="xs:string">
     <xsl:choose>
       <xsl:when test="starts-with(@href, '#')">
@@ -367,7 +255,7 @@
   <xsl:copy>
     <xsl:copy-of select="@* except @href"/>
     <xsl:attribute name="href" select="$href"/>
-    <xsl:apply-templates select="node()" mode="mp:copy-patch-toc2"/>
+    <xsl:apply-templates select="node()" mode="mp:copy-patch-toc"/>
   </xsl:copy>
 </xsl:template>
 

--- a/src/main/xslt/modules/chunk.xsl
+++ b/src/main/xslt/modules/chunk.xsl
@@ -9,10 +9,11 @@
                 xmlns:mp="http://docbook.org/ns/docbook/modes/private"
                 xmlns:t="http://docbook.org/ns/docbook/templates"
                 xmlns:v="http://docbook.org/ns/docbook/variables"
+                xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns="http://www.w3.org/1999/xhtml"
                 default-mode="m:docbook"
-                exclude-result-prefixes="db dbe f fp h m mp t v xs"
+                exclude-result-prefixes="#all"
                 version="3.0">
 
 <xsl:function name="f:chunk" as="attribute()*">
@@ -207,7 +208,7 @@
 
 <xsl:function name="fp:root-base-uri" as="xs:anyURI" cache="yes">
   <xsl:param name="node" as="element()"/>
-  <xsl:sequence select="resolve-uri($chunk-output-base-uri, base-uri(root($node)/*))"/>
+  <xsl:sequence select="$vp:chunk-output-base-uri"/>
 </xsl:function>
 
 <!-- ============================================================ -->

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -152,10 +152,28 @@
 <!-- Make sure we've resolved it so that file:///, file://, file:/, etc.
      get normalized because later on we're going to want to compare
      the prefix of this base URI with the prefix of another URI. -->
-<xsl:variable name="vp:chunk-output-base-uri" as="xs:anyURI?"
-              select="if ($v:chunk)
-                      then resolve-uri($chunk-output-base-uri, static-base-uri())
-                      else ()"/>
+<xsl:variable name="vp:chunk-output-base-uri" as="xs:anyURI?">
+  <xsl:choose>
+    <xsl:when use-when="function-available('ext:cwd')"
+              test="true()">
+      <xsl:if test="'chunks' = $v:debug">
+        <xsl:message select="'Chunk output base uri:',
+                             resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+      </xsl:if>
+      <xsl:sequence select="resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+    </xsl:when>
+    <xsl:when test="$v:chunk">
+      <xsl:if test="'chunks' = $v:debug">
+        <xsl:message select="'Chunk output base uri:',
+                             resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+      </xsl:if>
+      <xsl:sequence select="resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:sequence select="$chunk-output-base-uri"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:variable>
 
 <!-- I tinkered a bit to find images that would display across
      a variety of devices. YMMV. -->

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -164,10 +164,9 @@
     </xsl:when>
     <xsl:when test="$v:chunk">
       <xsl:if test="'chunks' = $v:debug">
-        <xsl:message select="'Chunk output base uri:',
-                             resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+        <xsl:message select="'Chunk output base uri:', $chunk-output-base-uri"/>
       </xsl:if>
-      <xsl:sequence select="resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+      <xsl:sequence select="$chunk-output-base-uri"/>
     </xsl:when>
     <xsl:otherwise>
       <xsl:sequence select="$chunk-output-base-uri"/>

--- a/src/test/java/org/docbook/xsltng/extensions/TestCwd.java
+++ b/src/test/java/org/docbook/xsltng/extensions/TestCwd.java
@@ -49,7 +49,18 @@ public class TestCwd extends TestCase {
             transformer.setInitialTemplate(new QName("", "main"));
             transformer.transform();
             XdmValue value = result.getXdmValue();
-            assertEquals(System.getProperty("user.dir") + "/", value.toString());
+
+            String expected = System.getProperty("user.dir");
+            if (expected.startsWith("/")) {
+                expected = "file:" + expected;
+            } else {
+                expected = "file:/" + expected;
+            }
+            if (!expected.endsWith("/")) {
+                expected += "/";
+            }
+
+            assertEquals(expected, value.toString());
         } catch (SaxonApiException sae) {
             sae.printStackTrace();
             TestCase.fail();


### PR DESCRIPTION
Fix #241 

Making the `ext:cwd()` function return an absolute URI means we don't have to resolve it against the `static-base-uri()` which is sometimes an `https:` URI. This necessitated reworking some aspects of `$chunk-output-base-uri` and `$vp:chunk-output-base-uri` a bit.

Tidied up some cruft in `chunk-output.xsl`

Publish the Sonatype release from CI so that the `$XSL:VERSION-ID` is correct.

