### PR TITLE
Fix fp:relative-uri

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.6'
-  guideVersion = '2.0.6'
+  xslTNGversion = '2.0.7'
+  guideVersion = '2.0.7'
   guidePrerelease = true
 
   docbookVersion = '5.2CR4'

--- a/src/guide/xml/changelog.xml
+++ b/src/guide/xml/changelog.xml
@@ -2,6 +2,21 @@
             xmlns:xlink="http://www.w3.org/1999/xlink">
 <?db revhistory-style="list"?>
 
+<revision xml:id="r207">
+<revnumber>2.0.7</revnumber>
+<date>2023-02-02</date>
+<revdescription>
+<para>This is still a pre-release; see <link linkend="r206">2.0.6</link>.</para>
+<itemizedlist>
+<listitem>
+<para>Fix a small bug caused by the fact that a string was being passed
+to a function that expected an <code>xs:anyURI</code>. It’s not a public function,
+so the simplest thing was just to let it accept strings.</para>
+</listitem>
+</itemizedlist>
+</revdescription>
+</revision>
+
 <revision xml:id="r206">
 <revnumber>2.0.6</revnumber>
 <date>2023-02-01</date>

--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -327,8 +327,8 @@
 </xsl:template>
 
 <xsl:function name="fp:relative-uri" as="xs:string">
-  <xsl:param name="rootbaseuri" as="xs:anyURI" required="yes"/>
-  <xsl:param name="chunkbaseuri" as="xs:anyURI" required="yes"/>
+  <xsl:param name="rootbaseuri" as="xs:string" required="yes"/>
+  <xsl:param name="chunkbaseuri" as="xs:string" required="yes"/>
   <xsl:param name="href" as="xs:string" required="yes"/>
 
   <xsl:variable name="absuri"


### PR DESCRIPTION
As defined, the function requires an `xs:anyURI`, but that's not always convenient so just let them be strings.