### PR TITLE
Pre-release version 2.0.9

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.0.8'
-  guideVersion = '2.0.8'
+  xslTNGversion = '2.0.9'
+  guideVersion = '2.0.9'
   guidePrerelease = true
 
   docbookVersion = '5.2CR5'
@@ -17,6 +17,6 @@ ext {
 
   metadataExtractorVersion = '2.18.0'
   jingVersion = '20220510'
-  xmlresolverVersion = '4.6.4'
-  sincludeVersion = '4.2.1'
+  xmlresolverVersion = '5.0.0'
+  sincludeVersion = '5.0.0'
 }

--- a/src/guide/xml/changelog.xml
+++ b/src/guide/xml/changelog.xml
@@ -2,16 +2,34 @@
             xmlns:xlink="http://www.w3.org/1999/xlink">
 <?db revhistory-style="list"?>
 
-<revision xml:id="r207">
-<revnumber>2.0.7</revnumber>
-<date>2023-02-02</date>
+<revision xml:id="r209">
+<revnumber>2.0.9</revnumber>
+<date>2023-02-13</date>
 <revdescription>
-<para>This is still a pre-release; see <link linkend="r206">2.0.6</link>.</para>
+<para>This is still a pre-release; see <link linkend="r208">2.0.8</link>.</para>
 <itemizedlist>
 <listitem>
-<para>Fix a small bug caused by the fact that a string was being passed
-to a function that expected an <code>xs:anyURI</code>. It’s not a public function,
-so the simplest thing was just to let it accept strings.</para>
+<para>There are no changes to the stylesheets in this release. It
+simply updates the XML Resolver to version 5.0.0 and the XInclude
+extension function to version 5.0.0.</para>
+<para>Hopefully, this is the last pre-release of the 2.x stylesheets.</para>
+</listitem>
+</itemizedlist>
+</revdescription>
+</revision>
+
+<revision xml:id="r208">
+<revnumber>2.0.8</revnumber>
+<date>2023-02-11</date>
+<revdescription>
+<para>This is still a pre-release; see <link linkend="r206">2.0.7</link>.</para>
+<itemizedlist>
+<listitem>
+<para>Fixed a bug in localization support (a missing localization file accidentally
+caused the transformation to terminate). Fixed a bug the initializer for
+<varname>v:chunk-output-base-uri</varname>. Added
+<parameter>mediaobject-grouped-by-type</parameter> to group media objects by
+type.</para>
 </listitem>
 </itemizedlist>
 </revdescription>

--- a/src/website/html/homepage.html
+++ b/src/website/html/homepage.html
@@ -44,9 +44,9 @@ also supported.</p>
 </a></p>
 
 <p>Documentation for the preview release
-is <a href="guide/2.0.8/">also available</a>
-(<a href="/epub/DocBook-xslTNG-2.0.8.epub">EPUB</a>,
-<a href="/pdf/DocBook-xslTNG-2.0.8.pdf">PDF</a>).</p>
+is <a href="guide/2.0.9/">also available</a>
+(<a href="/epub/DocBook-xslTNG-2.0.9.epub">EPUB</a>,
+<a href="/pdf/DocBook-xslTNG-2.0.9.pdf">PDF</a>).</p>
 
 <p class="note">The ability to publish different versions of the documentation
 simultaneously was added on 6 January 2023. If you have bookmarked pages from
@@ -54,7 +54,7 @@ earlier releases, you’ll need to update them. The plan is that
 <code>/guide</code> will always redirect you to the documentation for
 the current “production” release. Other releases are available under
 <code>/guide/<em>version</em></code>, for example
-<a href="guide/2.0.8/">guide/2.0.8/</a>.</p>
+<a href="guide/2.0.9/">guide/2.0.9/</a>.</p>
 
 <p>The <a href="https://xslt.xmlexplorer.com/">XSLT Explorer</a>
 summary of the stylesheets <a href="explorer/index.html">is also available</a>.
@@ -189,7 +189,7 @@ They are also available
 is version 1.11.2 published at 11:29 <a href="https://www.timeanddate.com/time/zones/gmt">GMT</a> on 03 Jan 2023.</p>
 </div>
 
-<p>The <a href="https://github.com/docbook/xslTNG/releases/2.0.8">latest prerelease</a>
+<p>The <a href="https://github.com/docbook/xslTNG/releases/2.0.9">latest prerelease</a>
 is version <?xsltng-version?> published <?pubdate?>.</p>
 </div>
 


### PR DESCRIPTION
This pre-release simply updates the dependencies for the XML Resolver and XInclude extension function to 5.0.0 (each, coincidentally). It also updates the change log in the user guide.
