### PR TITLE
`summary` attribute of `alt` tag does not validate xhtml output

### DIFF
--- a/src/main/xslt/modules/objects.xsl
+++ b/src/main/xslt/modules/objects.xsl
@@ -37,7 +37,7 @@
         <!-- do nothing -->
       </xsl:when>
       <xsl:when test="db:alt">
-        <xsl:attribute name="summary" select="normalize-space(db:alt)"/>
+        <xsl:attribute name="content" select="normalize-space(db:alt)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates select="(db:textobject[db:phrase])[1]"


### PR DESCRIPTION
`summary` attribute of `alt` tag does not validate xhtml output.
Proposed replacement with  `content`