### PR TITLE
Tweak the on-page ToC

### DIFF
--- a/src/main/web/js/pagetoc.js
+++ b/src/main/web/js/pagetoc.js
@@ -42,6 +42,7 @@
   let hidden_section = false;
   let nothing_to_reveal = HIDDEN;
   let idcount = 0;
+  let onscreen = false;
 
   const randomId = function() {
     idcount++;
@@ -180,8 +181,17 @@
   const centerMain = function() {
     // If the pagetoc is not displayed, just leave everything alone
     if (getComputedStyle(pagetoc).display == "none") {
+      if (onscreen) {
+        main.style.marginLeft = "auto";
+        main.style.marginRight = "auto";
+        main.style.paddingLeft = "0";
+        main.style.minWidth = mainMinWidthStyle;
+        main.style.maxWidth = mainMaxWidthStyle;
+      }
+      onscreen = false;
       return;
     }
+    onscreen = true;
 
     // Some padding
     const pad = 4*onerem;


### PR DESCRIPTION
When the window is made narrow enough to cause the on-page ToC to disappear, restore the margins and padding to recenter the body content.