### PR TITLE
Amend Dockerfile with arguments and metadata

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:18.04
-MAINTAINER Norman Tovey-Walsh <ndw@nwalsh.com>
+ARG UBUNTU_VERSION=18.04
+FROM ubuntu:${UBUNTU_VERSION}
+LABEL org.opencontainers.image.authors="Norman Tovey-Walsh <ndw@nwalsh.com>"
 
 RUN apt-get update
 RUN apt-get dist-upgrade -y


### PR DESCRIPTION
This PR contains the following changes:

* Add `UBUNTU_VERSION` argument (defaults to `18.04`) to make it easier to use specific Ubuntu versions at build time (use `docker build --build-args UBUNTU_VERSION=...`)
* Replace deprecated `MAINTAINER` key with `LABEL`