### PR TITLE
Attempt to avoid extra space below a callout list

### DIFF
--- a/src/main/scss/media-all.scss
+++ b/src/main/scss/media-all.scss
@@ -1367,6 +1367,14 @@ blockquote p + .attribution {
     font-family: var(--mono-family);
 }
 
+.calloutlist {
+    margin-bottom: 1em;
+}
+
+.calloutlist dl {
+    margin-bottom: 0;
+}
+
 .calloutlist dl dt {
     clear: both;
     float: left;
@@ -1380,6 +1388,10 @@ blockquote p + .attribution {
 
 .calloutlist dd > p:first-child {
     margin-top: 0;
+}
+
+.calloutlist dd:last-child > p:last-child {
+    margin-bottom: 0;
 }
 
 a.callout-bug,


### PR DESCRIPTION
There's some CSS trickery here to avoid extra space below a `calloutlist`. It will work when the last element of the last callout description is a `para`:

```
<calloutlist>
  ...
  <callout>
    ...
   <para>...</para>
  </callout>
</calloutlist>
```

I expect that (a) `calloutlist`s are fairly rare and (b) when they're used, they almost always contain paragraphs, so...

Close #310 