### PR TITLE
Fix list of block elements for $unwrap-paragraphs

### DIFF
--- a/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestGenerator.groovy
+++ b/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestGenerator.groovy
@@ -153,7 +153,8 @@ class TestGenerator {
 
     generatedConfigurations = [
       'para.002': ['unwrapped-para.002':'unwrapped'],
-      'para.003': ['unwrapped-para.003':'unwrapped']
+      'para.003': ['unwrapped-para.003':'unwrapped'],
+      'para.004': ['unwrapped-para.004':'unwrapped']
     ]
 
     configureCalloutTests()

--- a/src/main/xslt/modules/blocks.xsl
+++ b/src/main/xslt/modules/blocks.xsl
@@ -87,29 +87,33 @@
     <xsl:otherwise>
       <xsl:iterate select="node()">
         <xsl:param name="p" as="element(h:p)"><p/></xsl:param>
+        <xsl:message select="'NODE:', ."/>
         <xsl:choose>
-          <xsl:when test="self::db:blockquote|self::db:calloutlist|self::db:caution
-                          |self::db:classsynopsis|self::db:cmdsynopsis
+          <xsl:when test="self::db:address|self::db:bibliolist|self::db:blockquote
+                          |self::db:bridgehead|self::db:calloutlist|self::db:caution
+                          |self::db:classsynopsis|self::db:cmdsynopsis|self::db:constraintdef
                           |self::db:constructorsynopsis|self::db:danger
-                          |self::db:destructorsynopsis|self::db:epigraph
+                          |self::db:destructorsynopsis|self::db:enumsynopsis|self::db:epigraph
                           |self::db:equation|self::db:example|self::db:fieldsynopsis
-                          |self::db:figure|self::db:formalgroup
-                          |self::db:funcsynopsis|self::db:glosslist
-                          |self::db:important|self::db:informalequation
-                          |self::db:informalexample|self::db:informalfigure
-                          |self::db:informaltable|self::db:itemizedlist
-                          |self::db:mediaobject|self::db:methodsynopsis
-                          |self::db:msgset|self::db:note|self::db:ooclass
-                          |self::db:ooexception|self::db:oointerface|self::db:orderedlist
-                          |self::db:procedure|self::db:productionset
-                          |self::db:programlistingco|self::db:qandaset|self::db:revhistory
-                          |self::db:screenco|self::db:screenshot|self::db:segmentedlist
-                          |self::db:sidebar|self::db:table|self::db:tip
+                          |self::db:figure|self::db:formalgroup|self::db:funcsynopsis
+                          |self::db:glosslist|self::db:important|self::db:indexterm
+                          |self::db:informalequation|self::db:informalexample
+                          |self::db:informalfigure|self::db:informaltable|self::db:itemizedlist
+                          |self::db:literallayout|self::db:macrosynopsis|self::db:mediaobject
+                          |self::db:methodsynopsis|self::db:msgset|self::db:note
+                          |self::db:orderedlist|self::db:packagesynopsis|self::db:procedure
+                          |self::db:productionset|self::db:programlisting
+                          |self::db:programlistingco|self::db:qandaset|self::db:remark
+                          |self::db:revhistory|self::db:screen|self::db:screenco
+                          |self::db:screenshot|self::db:segmentedlist|self::db:sidebar
+                          |self::db:simplelist|self::db:synopsis|self::db:table|self::db:task
+                          |self::db:tip|self::db:typedefsynopsis|self::db:unionsynopsis
                           |self::db:variablelist|self::db:warning">
             <xsl:if test="not(empty($p/node()))
                           and not(normalize-space(string($p)) = '')">
               <xsl:sequence select="$p"/>
             </xsl:if>
+            <xsl:message select="."/>
             <xsl:apply-templates select="."/>
             <xsl:next-iteration>
               <xsl:with-param name="p" as="element(h:p)"><p/></xsl:with-param>

--- a/src/test/resources/xml/para.004.xml
+++ b/src/test/resources/xml/para.004.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+<title>Unit test: para.004</title>
+
+<para>Ordinary paragraph, followed by a paragraph with a program listing.</para>
+
+<para>This is some text followed by a programlisting: <programlisting language="xml"><![CDATA[<!-- stuff -->
+and nonsense]]></programlisting></para>
+
+<para>Ordinary paragraph.</para>
+
+</article>


### PR DESCRIPTION
I miscalculated when I was trying to work out the list of block elements that could occur inside a `para`. Fixed now, I think.

Close #319 
