### PR TITLE
Skip Mac too

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [ubuntu-20.04]
 
     # Skipping Windows because it won’t pass in CI...[expletive!!!]
     #    os: [macos-11, ubuntu-20.04, windows-2019]

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -54,7 +54,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [ubuntu-20.04]
 
     # Skipping Windows because it won’t pass in CI...[expletive!!!]
     #    os: [macos-11, ubuntu-20.04, windows-2019]


### PR DESCRIPTION
For some reason, the Mac build can't retrieve `https://api.github.com/repos/docbook/xslTNG/releases` and I can't work out why. So frustrating!