### PR TITLE
Support translate attribute

### DIFF
--- a/src/guide/xml/ref-functions.xml
+++ b/src/guide/xml/ref-functions.xml
@@ -1533,6 +1533,42 @@ is automatically escaped.</para>
 </refsection>
 </refentry>
 
+<refentry xml:id="f_translate-attribute">
+<?db filename="f_translate-attribute"?>
+<refmeta>
+<refentrytitle>f:translate-attribute</refentrytitle>
+<refmiscinfo>{http://docbook.org/ns/docbook/functions}translate-attribute#1</refmiscinfo>
+<refmiscinfo class="version">2.1.3</refmiscinfo>
+</refmeta>
+<refnamediv>
+<refname>f:translate-attribute</refname>
+<refpurpose>Controls the translate attribute</refpurpose>
+<refclass>function</refclass>
+</refnamediv>
+<refsection>
+<title>Description</title>
+<para>When computing what attributes to put on elements in the output, this function
+is called to check whether a <tag class="attribute">translate</tag> attribute should be 
+output:</para>
+<itemizedlist>
+<listitem>
+<para>If it returns true, a <tag class="attribute">translate</tag> attribute with the
+value “<code>yes</code>” will be output.</para>
+</listitem>
+<listitem>
+<para>If it returns false, a <tag class="attribute">translate</tag> attribute with the
+value “<code>no</code>” will be output.</para>
+</listitem>
+<listitem>
+<para>If it returns the empty sequence, no <tag class="attribute">translate</tag> attribute
+will be output.</para>
+</listitem>
+</itemizedlist>
+<para>The default implementation of this function checks the (local) name of the
+element with the <parameter>translate-suppress-elements</parameter> list.</para>
+</refsection>
+</refentry>
+
 <refentry xml:id="f_unique-id">
 <?db filename="f_unique-id"?>
 <refmeta>

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -5404,4 +5404,23 @@ The copied text will not include any callouts or other decorations in the listin
 </refsection>
 </refentry>
 
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <varname>translate-suppress-elements</varname>
+      <initializer>''</initializer>
+    </fieldsynopsis>
+    <refmiscinfo class="version">2.1.3</refmiscinfo>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>Elements in which translation is suppressed</refpurpose>
+  </refnamediv>
+<refsection>
+<title>Description</title>
+<para>This parameter is a list of (local) element names. Any output for these elements
+will have the <tag class="attribute">translate</tag> attribute with the value
+“<code>no</code>”.</para>
+</refsection>
+</refentry>
+
 </reference>

--- a/src/main/xslt/modules/functions.xsl
+++ b/src/main/xslt/modules/functions.xsl
@@ -19,6 +19,16 @@
 <xsl:key name="id" match="*" use="@xml:id"/>
 <xsl:key name="genid" match="*" use="generate-id(.)"/>
 
+<xsl:variable name="vp:translate-suppress-elements"
+              select="tokenize($translate-suppress-elements, '\s+')"/>
+
+<xsl:function name="f:translate-attribute" as="xs:boolean?">
+  <xsl:param name="node" as="element()"/>
+  <xsl:if test="local-name($node) = $vp:translate-suppress-elements">
+    <xsl:sequence select="false()"/>
+  </xsl:if>
+</xsl:function>
+
 <xsl:function name="f:attributes" as="attribute()*">
   <xsl:param name="node" as="element()"/>
   <xsl:param name="attributes" as="attribute()*"/>
@@ -81,6 +91,11 @@
     <xsl:if test="exists($classes)">
       <xsl:attribute name="class" select="string-join($classes, ' ')"/>
     </xsl:if>
+  </xsl:if>
+
+  <xsl:variable name="translate" select="f:translate-attribute($node)"/>
+  <xsl:if test="exists($translate)">
+    <xsl:attribute name="translate" select="if ($translate) then 'yes' else 'no'"/>
   </xsl:if>
 </xsl:function>
 


### PR DESCRIPTION
This PR adds a `$translate-suppress-elements` parameter and a `f:translate-attribute` function to support adding `translate="no"` to elements that should not be translated.

(How this is useful in the HTML output is, now that I consider it more carefully, less obvious.)

Fix #335 