### PR TITLE
Publish a distribution without Saxon

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -142,6 +142,7 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             build/distributions/docbook-xslTNG-${{ env.CI_TAG }}.zip
+            build/distributions/docbook-xslTNG-nosaxon-${{ env.CI_TAG }}.zip
 
       - name: Publish to Sonatype
         if: ${{ env.HAVE_GPGKEYURI == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}

--- a/build.gradle
+++ b/build.gradle
@@ -938,6 +938,13 @@ task zipDist(type: Zip, dependsOn: ['zipStage']) {
   archiveFileName = "${xslTNGbaseName}-${xslTNGversion}.zip"
 }
 
+task zipDistNoSaxon(type: Zip, dependsOn: ['zipStage']) {
+  from("${buildDir}/stage/zip")
+  exclude "libs/lib/Saxon*"
+  into "${xslTNGbaseName}-nosaxon-${xslTNGversion}"
+  archiveFileName = "${xslTNGbaseName}-nosaxon-${xslTNGversion}.zip"
+}
+
 task relnotes(
   description: "Checks for release notes",
 ) {
@@ -965,7 +972,8 @@ task relnotes(
 // ============================================================
 
 task dist(
-  dependsOn: ['requirePassingTests', 'releaseArtifacts', 'zipDist', 'website', 'relnotes']
+  dependsOn: ['requirePassingTests', 'releaseArtifacts',
+              'zipDist', 'zipDistNoSaxon', 'website', 'relnotes']
 ) {
   doLast {
     println("Built dist for ${xslTNGtitle} version ${xslTNGversion}")


### PR DESCRIPTION
The root cause of #311 is that Oxygen includes Saxon and if the DocBook xslTNG jar file also includes a different *version* of Saxon, bad happens. To avoid this, I'm adding a `docbook-xslTNG-nosaxon-x.y.z.zip` release that doesn't bundle Saxon. That's the version to use if you want to use the stylesheets in Oxygen or some other environment that bundles its own version of Saxon.

Fix #311 
