### PR TITLE
Make .xspec tasks depend on expected results

### DIFF
--- a/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestConfiguration.groovy
@@ -187,6 +187,7 @@ class TestConfiguration {
       inputs.files project.fileTree(dir: "${project.projectDir}/src/main/xslt")
       inputs.file "${project.projectDir}/src/guide/xml/ref-params.xml"
       inputs.files project.fileTree(dir: "${project.projectDir}/src/test/resources/xml")
+      inputs.files project.fileTree(dir: "${project.projectDir}/src/test/resources/expected")
       inputs.file xfile
       testCases.each { tcase ->
         inputs.file tcase.input


### PR DESCRIPTION
Fix #339 
