### PR TITLE
Exclude old Xerces implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
   configurations.all {
     resolutionStrategy {
       exclude group: 'xml-apis', module: 'xml-apis'
+      exclude group: 'xerces', module: 'xercesImpl'
       force "${saxonGroup}:${saxonEdition}:${saxonVersion}",
         "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
     }
@@ -79,6 +80,7 @@ apply from: 'properties.gradle'
 configurations.all {
   resolutionStrategy {
     exclude group: 'xml-apis', module: 'xml-apis'
+    exclude group: 'xerces', module: 'xercesImpl'
     force "${saxonGroup}:${saxonEdition}:${saxonVersion}",
       "org.xmlresolver:xmlresolver:${xmlresolverVersion}"
   }


### PR DESCRIPTION
An old Xerces implementation (2.9.1) is pulled in via a transitive dependency. It contains a bug that causes an array out-of-bounds exception on systems that use UTF-16. (Some Windows systems?) A more recent version ships with modern JDKs.