### PR TITLE
Fix Pygmentize issues on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1098,7 +1098,7 @@ task guide(
   )
 
   doLast {
-    delete "${buildDir}/guide/irrelevant-and-deleted-file.html"
+    delete "${uBuildDir}/guide/irrelevant-and-deleted-file.html"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -252,9 +252,12 @@ def pygmentize = findPygmentize()
 def findPygmentize() {
   def path = System.getenv()["PATH"] == null ? System.getenv()["Path"] : System.getenv()["PATH"]
   def script = null
-  path.split(":+").each { segment ->
+  def pathsep = System.getProperty("path.separator")
+  def pygmentize = OperatingSystem.current().isWindows() ? 'pygmentize.exe' : 'pygmentize'
+
+  path.split(pathsep).each { segment ->
     if (script == null) {
-      def testfile = new File("${segment}/pygmentize")
+      def testfile = new File("${segment}/${pygmentize}")
       if (testfile.exists() && testfile.canExecute()) {
         script = testfile.toString()
       }
@@ -264,7 +267,7 @@ def findPygmentize() {
         def pyenv = new File("${segment.substring(0, segment.length() - 6)}/versions")
         def versions = []
         pyenv.traverse(type: DIRECTORIES, maxDepth: 0) { dir ->
-          testfile = new File("${dir}/bin/pygmentize")
+          testfile = new File("${dir}/bin/${pygmentize}")
           if (testfile.exists() && testfile.canExecute()) {
             script = testfile.toString()
           }

--- a/buildSrc/src/main/java/org/docbook/xsltng/extensions/Pygmentize.java
+++ b/buildSrc/src/main/java/org/docbook/xsltng/extensions/Pygmentize.java
@@ -34,10 +34,12 @@ import java.util.List;
  */
 
 public class Pygmentize extends PygmentizeDefinition {
-    private final String format = "html"; // no others are supported
-
     private static final StructuredQName qName =
             new StructuredQName("", "http://docbook.org/extensions/xslt", "pygmentize");
+
+    public Pygmentize() {
+        computeExecutable();
+    }
 
     @Override
     public StructuredQName getFunctionQName() {
@@ -116,7 +118,7 @@ public class Pygmentize extends PygmentizeDefinition {
             List<String> cmdline = new ArrayList<String>();
             cmdline.add(pygmentize);
             cmdline.add("-f");
-            cmdline.add(format);
+            cmdline.add("html"); // no others are supported
             if (language != null) {
                 cmdline.add("-l");
                 cmdline.add(language);

--- a/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeAvailable.java
+++ b/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeAvailable.java
@@ -24,6 +24,10 @@ public class PygmentizeAvailable extends PygmentizeDefinition {
     private static final StructuredQName qName =
             new StructuredQName("", "http://docbook.org/extensions/xslt", "pygmentize-available");
 
+    public PygmentizeAvailable() {
+        computeExecutable();
+    }
+
     @Override
     public StructuredQName getFunctionQName() {
         return qName;

--- a/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeCall.java
+++ b/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeCall.java
@@ -11,8 +11,6 @@ abstract public class PygmentizeCall extends ExtensionFunctionCall {
     protected DebuggingLogger logger = null;
 
     public String findPygmentize(Configuration config, String executable, boolean noisy) {
-        // I'm trying to make this Windows-compatible, but I'm not testing it there...
-        String[] paths = System.getenv("PATH").split(File.pathSeparator);
         String pygmentize = null;
 
         if (System.getProperty(PYGMENTIZE) != null) {
@@ -23,11 +21,18 @@ abstract public class PygmentizeCall extends ExtensionFunctionCall {
                 return pygmentize;
             } else {
                 message("Cannot use pygmentize: " + System.getProperty(PYGMENTIZE), noisy);
-                pygmentize = null;
+                return null;
             }
         } else {
             message("Searching for pygmentize", noisy);
         }
+
+        // I'm trying to make this Windows-compatible, but I'm not (routinely) testing it there...
+        String pathEnv = System.getenv("PATH");
+        if (pathEnv == null) {
+            pathEnv = System.getenv("Path");
+        }
+        String[] paths = pathEnv == null ? new String[0] : pathEnv.split(File.pathSeparator);
 
         for (String path : paths) {
             if (pygmentize == null && !"".equals(path)) {

--- a/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeDefinition.java
+++ b/buildSrc/src/main/java/org/docbook/xsltng/extensions/PygmentizeDefinition.java
@@ -3,7 +3,19 @@ package org.docbook.xsltng.extensions;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
 
 abstract public class PygmentizeDefinition extends ExtensionFunctionDefinition {
-    protected String executable = "pygmentize";
+    protected String executable = null;
     protected Boolean foundPygmentize = null;
     protected String pygmentize = null;
+
+    protected boolean isWindows() {
+        return System.getProperty("os.name", "unknown").toLowerCase().contains("win");
+    }
+
+    protected void computeExecutable() {
+        if (isWindows()) {
+            executable = "pygmentize.exe";
+        } else {
+            executable = "pygmentize";
+        }
+    }
 }

--- a/src/guide/xml/ref-functions.xml
+++ b/src/guide/xml/ref-functions.xml
@@ -2097,10 +2097,17 @@ the listing if you are trying to accurately count the lines.</para>
 </refsynopsisdiv>
 <refsection>
 <title>Description</title>
-<para>In order to run Pygments on listings,
-the <function>ext:pygmentize</function> extension function must be available
-<emphasis>and</emphasis> the <command>pygmentize</command> command must be available
-on the host system.</para>
+<para>In order to run Pygments on listings, the
+<function>ext:pygmentize</function> extension function must be
+available <emphasis>and</emphasis> the <command>pygmentize</command>
+(<command>pygmentize.exe</command> on Windows) command must be
+available on the host system.</para>
+
+<para>If it’s inconvenient to put <command>pygmentize</command> on the system path,
+you can specify an explicit location with the Java system property
+<literal>org.docbook.xsltng.extensions.pygmentize</literal>. The value of the property
+should be the fully qualified path name of the executable.</para>
+
 <para>This function returns true if it successfully finds the
 <command>pygmentize</command> command on the system path.</para>
 </refsection>


### PR DESCRIPTION
1. Correctly search for `pygmentize.exe` on Windows.
2. Document the `org.docbook.xsltng.extensions.pygmentize` system property

Close #372 