### PR TITLE
Fix Pygments for the Guide on Windows

### DIFF
--- a/src/guide/xsl/common.xsl
+++ b/src/guide/xsl/common.xsl
@@ -73,6 +73,11 @@
 
 <!-- ============================================================ -->
 
+<xsl:variable name="v:verbatim-syntax-highlight-pygments-options"
+           select="map {'encoding': 'utf-8'}"/>
+
+<!-- ============================================================ -->
+
 <xsl:template match="db:book" mode="m:generate-titlepage">
   <header>
     <div class="cover">

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -178,7 +178,8 @@
 </xsl:variable>
 
 <!-- I tinkered a bit to find images that would display across
-     a variety of devices. YMMV. -->
+     a variety of devices. YMMV. Beware: Pygmentize on Windows
+     doesn't use UTF-8 by default, so bad can happen. -->
 <xsl:variable name="v:admonition-icons">
   <db:tip>☞</db:tip>
   <db:note>ⓘ</db:note>


### PR DESCRIPTION
On Windows, there's no defaulting to UTF-8 (*eyeroll*) so Pygments fails on some Unicode characters. This is, I suppose, partly a consequence of getting Pygmentize to run on Windows. Sigh.