### PR TITLE
Skip Windows in the matrix build

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-20.04]
 
     steps:
       - name: Install platform-independent Python modules

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-20.04]
 
     steps:
       - name: Install platform-independent Python modules


### PR DESCRIPTION
I am once again removing `windows-2019` from the matrix build. Even though I've specified `'encoding': 'utf-8'` in the Pygmentize options, it's failing on a literal non-breaking space in the input file. Life is too [expletive] short.