### PR TITLE
Add support for xref/@xrefstyle (Issue 414)

### DIFF
--- a/src/main/xslt/modules/links.xsl
+++ b/src/main/xslt/modules/links.xsl
@@ -232,25 +232,11 @@
               <xsl:apply-templates select="." mode="m:crossref-xrefstyle"/>
             </xsl:variable>
             
-            <xsl:variable name="label" as="item()*">
-              <xsl:if test="$template/lt:label">
-                <xsl:apply-templates select="$target" mode="m:crossref-label"/>
-              </xsl:if>
-            </xsl:variable>
-            
-            <xsl:variable name="title" as="node()*">
-              <xsl:if test="$template/lt:content">
-                <xsl:apply-templates select="$target" mode="m:crossref-title">
-                  <xsl:with-param name="purpose" select="'crossref'"/>
-                </xsl:apply-templates>
-              </xsl:if>
-            </xsl:variable>
-         
-            <xsl:apply-templates select="$template" mode="mp:localization">
-              <xsl:with-param name="context" select="$target"/>
-              <xsl:with-param name="label" select="$label"/>
-              <xsl:with-param name="content" select="$title"/>
-            </xsl:apply-templates>
+            <!-- see xref.xsl -->
+            <xsl:call-template name="tp:apply-xref-template">
+              <xsl:with-param name="target" select="$target"/>
+              <xsl:with-param name="template" select="$template"/>
+            </xsl:call-template>
             
           </xsl:when>
           <xsl:otherwise>

--- a/src/main/xslt/modules/xref.xsl
+++ b/src/main/xslt/modules/xref.xsl
@@ -9,6 +9,7 @@
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
                 xmlns:mp="http://docbook.org/ns/docbook/modes/private"
+                xmlns:tp="http://docbook.org/ns/docbook/templates/private"
                 xmlns:v="http://docbook.org/ns/docbook/variables"
                 xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -82,22 +83,32 @@
   <xsl:message select="local-name(.), $context, $template"/>
   -->
 
+  <xsl:call-template name="tp:apply-xref-template">
+    <xsl:with-param name="target" select="."/>
+    <xsl:with-param name="template" select="$template"/>
+  </xsl:call-template>
+</xsl:template>
+  
+<!-- Apply the crossreference template to the xref target -->  
+<xsl:template name="tp:apply-xref-template">
+  <xsl:param name="template" as="element(l:template)"/>
+  <xsl:param name="target" as="element()"/>
   <xsl:variable name="label" as="item()*">
     <xsl:if test="$template/lt:label">
-      <xsl:apply-templates select="." mode="m:crossref-label"/>
+      <xsl:apply-templates select="$target" mode="m:crossref-label"/>
     </xsl:if>
   </xsl:variable>
 
   <xsl:variable name="title" as="node()*">
     <xsl:if test="$template/lt:content">
-      <xsl:apply-templates select="." mode="m:crossref-title">
+      <xsl:apply-templates select="$target" mode="m:crossref-title">
         <xsl:with-param name="purpose" select="'crossref'"/>
       </xsl:apply-templates>
     </xsl:if>
   </xsl:variable>
 
   <xsl:apply-templates select="$template" mode="mp:localization">
-    <xsl:with-param name="context" select="."/>
+    <xsl:with-param name="context" select="$target"/>
     <xsl:with-param name="label" select="$label"/>
     <xsl:with-param name="content" select="$title"/>
   </xsl:apply-templates>


### PR DESCRIPTION
This is my very first pull request, i hope i am doing it right.

Changes in `link.xsl` and `xref.xsl` for a minimal support of `xref/@xrefstyle` (Issue 414). 

If an _xrefstyle_ attribute exists, a `l:template` Element is created on the fly by analyzing the xrefstyle content, and applied with a new `tp:apply-xref-template` Template. Only two of the _Template %-letter substitutions_ from Table 4.1 in the reference Manual are supported: 

- %c (content) gives an `lt:content`Element;
- %l (label) gives an `lt:label` Element
- Anything else is wrapped in an `lt:text` Element.

Greetings, Frank
  