### PR TITLE
Introduce a new parameter $intermediate-docbook-uri

### DIFF
--- a/src/guide/xml/ch04.xml
+++ b/src/guide/xml/ch04.xml
@@ -595,15 +595,15 @@ Oxygen change markup processing instructions.
 </listitem>
 </orderedlist>
 
-<para>A customization can introduce transformations to the original
-document: before the standard transformations by specifying them in
-<parameter>transform-original</parameter>; after the standard transformations
-but before the transformation to HTML by specifying them in
-<parameter>transform-before</parameter>; or after the HTML transformation
-by specifying them in <parameter>transform-after</parameter>. (If you need
-to insert a transformation in the middle of the standard transformations,
-you’ll have to update the <varname>v:standard-transforms</varname>
-variable.)</para>
+<para>A customization can introduce transformations to the original document: before the standard
+      transformations by specifying them in <parameter>transform-original</parameter>; after the
+      standard transformations but before the transformation to HTML by specifying them in
+        <parameter>transform-before</parameter>; or after the HTML transformation by specifying them
+      in <parameter>transform-after</parameter>. (If you need to insert a transformation in the
+      middle of the standard transformations, you’ll have to update the
+        <varname>v:standard-transforms</varname> variable.) If you want to see the normalized and
+      augmented DocBook content just before the conversion to HTML starts, you can use the
+        <parameter>intermediate-docbook-uri</parameter> parameter.</para>
 
 <note>
 <para>Transformations in <varname>transform-after</varname> will be processing

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -2173,6 +2173,38 @@ of the entries for each section. This results in a more complete index while
 still preserving the ability to see in which sections the terms occur.</para>
 </refsection>
 </refentry>
+  
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string</type>
+      <varname>intermediate-docbook-uri</varname>
+      <initializer>''</initializer>
+    </fieldsynopsis>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>URI for intermediate DocBook content</refpurpose>
+  </refnamediv>
+  <refsection>
+    <title>Description</title>
+    <para>If the parameter is not empty, a file with the content of the input document to which
+      the following transformations have been applied is written to the specified location: </para>
+    <orderedlist>
+      <listitem>
+        <para>transformations from <parameter>transform-original</parameter>, if any;</para>
+      </listitem>
+      <listitem>
+        <para>standard transformations (see <varname>v:standard-transforms</varname>);</para>
+      </listitem>
+      <listitem>
+        <para>transformations from <parameter>transform-before</parameter>, if any.</para>
+      </listitem>
+    </orderedlist>
+      <para>It is the normalized and augmented DocBook content immediatly before transformations
+        into HTML begins. If the URI is relative, it will be resolved against the base-input
+        documents <code>base-uri(/)</code>.</para>
+  </refsection>
+</refentry>  
 
 <refentry>
   <refmeta>


### PR DESCRIPTION
See Issue 440. If the new parameter is not empty, the normalized and augmented DocBook content after the main transwormations is writte to a file at the specified location. It is described in the reference guide.