### PR TITLE
Don't build on MacOS in CI

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Install platform-independent Python modules

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Install platform-independent Python modules


### PR DESCRIPTION
Building on MacOS was added when I thought I could get building working on all three platforms (Linux, MacOS, Windows). Since Windows is a persistent fail, let's not waste CPU on MacOS which is very unlikely to differ from Linux.
