### PR TITLE
Allow pre/post processing transforms to be passed from the command line

### DIFF
--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -108,9 +108,9 @@
       <xsl:when test=". instance of map(*)">
         <xsl:sequence select="."/>
       </xsl:when>
-      <xsl:when test=". instance of xs:string">
+      <xsl:when test=". instance of xs:string or . instance of xs:untypedAtomic">
         <xsl:sequence select="map {
-            'stylesheet-location': resolve-uri(., base-uri(/))
+            'stylesheet-location': resolve-uri(., static-base-uri())
           }"/>
       </xsl:when>
       <xsl:otherwise>
@@ -127,9 +127,9 @@
       <xsl:when test=". instance of map(*)">
         <xsl:sequence select="."/>
       </xsl:when>
-      <xsl:when test=". instance of xs:string">
+      <xsl:when test=". instance of xs:string or . instance of xs:untypedAtomic">
         <xsl:sequence select="map {
-            'stylesheet-location': resolve-uri(., base-uri(/))
+            'stylesheet-location': resolve-uri(., static-base-uri())
           }"/>
       </xsl:when>
       <xsl:otherwise>
@@ -228,9 +228,9 @@
         <xsl:when test=". instance of map(*)">
           <xsl:sequence select="."/>
         </xsl:when>
-        <xsl:when test=". instance of xs:string">
+        <xsl:when test=". instance of xs:string or . instance of xs:untypedAtomic">
           <xsl:sequence select="map {
-                                  'stylesheet-location': resolve-uri(., base-uri(/))
+                                  'stylesheet-location': resolve-uri(., static-base-uri())
                                 }"/>
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
I think this is a simpler solution to #426 than proposed in #439. The root cause appears to be that a parameter passed on the command line is not a string, it is an `xs:untypedAtomic`. That makes sense because untyped atomic values are more amenable to automatic conversion.

Fixing the first problem (allowing `instance of xs:untypedAtomic`) reveals a second; the variables are attempting to use the root of the input document when it isn't available. I think `static-base-uri()` is a reasonable compromise. 

Close #426 
Close #439 