### PR TITLE
Add parameters to capture intermediate transformation results

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -1132,6 +1132,17 @@ each image.
 </varlistentry>
 <varlistentry>
 <term>
+<enumvalue>intermediate-results</enumvalue>
+</term>
+<listitem>
+<para>Output the resolved names of intermediate result documents
+(<parameter>transformed-docbook-input</parameter>
+and <parameter>transformed-docbook-output</parameter>) if they are used.
+</para>
+</listitem>
+</varlistentry>
+<varlistentry>
+<term>
 <enumvalue>intra-chunk-links</enumvalue>
 </term>
 <listitem>
@@ -5507,5 +5518,85 @@ in the online stylesheets (but might in the future).</para>
 </refsection>
 </refentry>
 
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string?</type>
+      <varname>transformed-docbook-input</varname>
+      <initializer>()</initializer>
+    </fieldsynopsis>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>URI for transformed DocBook input</refpurpose>
+  </refnamediv>
+  <refsection>
+    <title>Description</title>
+    <para>Broadly speaking, the DocBook transformation process has
+    three phases:</para>
+    <orderedlist>
+      <listitem>
+        <para>The DocBook input supplied by the user is run through a
+        series of transformations to produce a document that is ready
+        to be transformed to HTML. (See <xref linkend="preprocessing-pipeline"/>.)</para>
+      </listitem>
+      <listitem>
+        <para>That document is transformed into “HTML”. It’s not really HTML (yet)
+        because some aspects (footnotes, chunking, etc.) are not yet resolved.
+        (See <parameter>transformed-docbook-output</parameter>.)
+        </para>
+      </listitem>
+      <listitem>
+        <para>The “HTML” from the previous step is transformed to produce one
+        (or more) HTML results.
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>If the <parameter>transformed-docbook-input</parameter> parameter is not the empty
+    sequence, it is assumed to be a URI. It will be made absolute against the base URI of the
+    input document.
+    The transformed DocBook that results from step 1 above will be
+    output to that location.</para>
+  </refsection>
+</refentry>  
+
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string?</type>
+      <varname>transformed-docbook-output</varname>
+      <initializer>()</initializer>
+    </fieldsynopsis>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>URI for transformed DocBook output</refpurpose>
+  </refnamediv>
+  <refsection>
+    <title>Description</title>
+    <para>Broadly speaking, the DocBook transformation process has
+    three phases:</para>
+    <orderedlist>
+      <listitem>
+        <para>The DocBook input supplied by the user is run through a
+        series of transformations to produce a document that is ready
+        to be transformed to HTML. (See <parameter>transformed-docbook-input</parameter>.)</para>
+      </listitem>
+      <listitem>
+        <para>That document is transformed into “HTML”. It’s not really HTML (yet)
+        because some aspects (footnotes, chunking, etc.) are not yet resolved.
+        </para>
+      </listitem>
+      <listitem>
+        <para>The “HTML” from the previous step is transformed to produce one
+        (or more) HTML results.
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>If the <parameter>transformed-docbook-output</parameter>
+    parameter is not the empty sequence, it is assumed to be a URI. It
+    will be made absolute against the base URI of the input document.
+    The transformed “HTML” that results from step 2 above will be
+    output to that location.</para>
+  </refsection>
+</refentry>  
 
 </reference>

--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:db="http://docbook.org/ns/docbook"
                 xmlns:dbe="http://docbook.org/ns/docbook/errors"
+                xmlns:err='http://www.w3.org/2005/xqt-errors'
                 xmlns:ext="http://docbook.org/extensions/xslt"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
@@ -203,22 +204,52 @@
                                   map { xs:QName('vp:starting-base-uri'): $starting-base-uri })"/>
   </xsl:variable>
 
-  <!--
-  <xsl:result-document href="/tmp/out.xml" method="xml" indent="yes">
+  <xsl:if test="string($transformed-docbook-input) != ''">
+    <xsl:try>
+      <xsl:variable name="href" 
+                    select="resolve-uri($transformed-docbook-input, base-uri(/))"/>
+      <xsl:result-document href="{$href}" method="xml" indent="no"
+                           exclude-result-prefixes="#all">
+        <xsl:sequence select="$document"/>
+      </xsl:result-document>
+      <xsl:if test="$v:debug = 'intermediate-results'">
+        <xsl:message select="'Transformed DocBook input saved:', $href"/>
+      </xsl:if>
+      <xsl:catch>
+        <xsl:message select="'Failed to save transformed input:', $transformed-docbook-input"/>
+        <xsl:message select="$err:description"/>
+      </xsl:catch>
+    </xsl:try>
+  </xsl:if>
+
+  <xsl:variable name="transformed-html" as="document-node()">
     <xsl:apply-templates select="$document" mode="m:docbook">
       <xsl:with-param name="vp:loop-count" select="1" tunnel="yes"/>
     </xsl:apply-templates>
-  </xsl:result-document>
-  -->
+  </xsl:variable>
+
+  <xsl:if test="string($transformed-docbook-output) != ''">
+    <xsl:try>
+      <xsl:variable name="href" 
+                    select="resolve-uri($transformed-docbook-output, base-uri(/))"/>
+      <xsl:result-document href="{$href}" method="xml" indent="no"
+                           exclude-result-prefixes="#all">
+        <xsl:sequence select="$transformed-html"/>
+      </xsl:result-document>
+      <xsl:if test="$v:debug = 'intermediate-results'">
+        <xsl:message select="'Transformed DocBook output saved:', $href"/>
+      </xsl:if>
+      <xsl:catch>
+        <xsl:message select="'Failed to save transformed output:', $transformed-docbook-output"/>
+        <xsl:message select="$err:description"/>
+      </xsl:catch>
+    </xsl:try>
+  </xsl:if>
 
   <xsl:variable name="result" as="document-node()">
     <xsl:call-template name="t:chunk-cleanup">
       <xsl:with-param name="docbook" select="$document"/>
-      <xsl:with-param name="source">
-        <xsl:apply-templates select="$document" mode="m:docbook">
-          <xsl:with-param name="vp:loop-count" select="1" tunnel="yes"/>
-        </xsl:apply-templates>
-      </xsl:with-param>
+      <xsl:with-param name="source" select="$transformed-html"/>
     </xsl:call-template>
   </xsl:variable>
 


### PR DESCRIPTION
This PR addresses #440 by adding two new parameters `transformed-docbook-input` and `transformed-docbook-output` to capture the pre-processed DocBook input that will be transformed into HTML and the immediate (HTML-ish) results of that transformation (before chunking).

I've adopted @fsteimke 's proposal in #441 slightly. I've only ever wanted these intermediate results for debugging, and I've been satisfied to just tweak the stylesheets when necessary (for example, the block of commented-out code that's been removed in this PR). But making them options seems reasonable and in that case, I can imagine wanting to capture either one, depending on what I'm debugging.

Thank you, Frank!

Close #440 
Close #441 