### PR TITLE
Issue 411: Do not warn if a table width is exactly nominal page width

### DIFF
--- a/src/main/xslt/modules/tablecals.xsl
+++ b/src/main/xslt/modules/tablecals.xsl
@@ -390,7 +390,7 @@
   <xsl:variable name="absolute-remainder"
                 select="f:absolute-length($v:nominal-page-width) - $absolute-width"/>
 
-  <xsl:if test="$absolute-remainder le 0">
+  <xsl:if test="$absolute-remainder lt 0">
     <xsl:message>Table width exceeds nominal width, ignoring relative width</xsl:message>
   </xsl:if>
 


### PR DESCRIPTION
A warning will appear only if the width of a table is greater than the nominal page width, but not if it is equal.

I hope that there are no problems with whitespace which makes comparison difficult. Otherwise give me a hint.

Greetings, Frank