### PR TITLE
A new note admonition in section 2.1 informs that you must enable xinclude with a command line switch

### DIFF
--- a/src/guide/xml/ch02.xml
+++ b/src/guide/xml/ch02.xml
@@ -168,6 +168,11 @@ the <filename>xslt/docbook.xsl</filename> stylesheet will be used automatically.
 </listitem>
 </varlistentry>
 </variablelist>
+    <note>
+      <title>Processing modular DocBook files</title>
+      <para>Please note that in the case of modular DocBook documents, you must explicitly enable
+        xi:include processing by using the <code>-xi:on</code> parameter.</para>
+    </note>
 </section>
 
 <section xml:id="python-script">


### PR DESCRIPTION
Adds a note in the reference guide for processing modular DocBook files.

I hope that there are no problems with whitespace which makes comparison difficult. Otherwise give me a hint.

Greetings, Frank