### PR TITLE
Try a little harder to scroll the ptoc into view

### DIFF
--- a/src/main/web/js/persistent-toc.js
+++ b/src/main/web/js/persistent-toc.js
@@ -134,12 +134,26 @@
                                     + window.location.hash);
       }
 
-      let path = window.location.pathname.substring(1) + window.location.hash;
+      // Try path#hash
+      let path = url.substring(1) + hash;
       let target = document.querySelector("nav.toc div a[rel-path='"+path+"']");
       if (target) {
         target.scrollIntoView();
       } else {
-        console.log(`ToC scroll, no match: ${path}`);
+        // Try #hash
+        target = document.querySelector("nav.toc div a[rel-path='"+hash+"']");
+        if (target) {
+          target.scrollIntoView();
+        } else {
+          // Try path
+          target = document.querySelector("nav.toc div a[rel-path='"+url.substring(1)+"']");
+          if (target) {
+            target.scrollIntoView();
+          } else {
+            // ???
+            console.log(`ToC scroll, no match: ${path}`);
+          }
+        }
       }
 
       if (!searchListener) {


### PR DESCRIPTION
The persistent ToC is augmented with `rel-path` values. If there's a single file, those values may be just ids (`#id`) where the current JavaScript looks for `file#id`. This patch isn't terribly clever, it just looks for `path#id`, `#id`, and `path`, taking the first it finds.

Fix #451