### PR TITLE
Improve homepage and PDF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1242,6 +1242,21 @@ task webGuide(
       writer.println('</body>')
       writer.println('</html>')
       writer.close()
+
+      def epub = "DocBook-xslTNG-${guideVersion}.epub"
+      html = new File("${buildDir}/website/epub/index.html")
+      writer = new PrintStream(html)
+      writer.println('<!DOCTYPE html>')
+      writer.println('<html>')
+      writer.println('<head>')
+      writer.println("<meta http-equiv='refresh' content=\"0; url='${epub}'\" />")
+      writer.println('</head>')
+      writer.println('<body>')
+      writer.println('<p>The current EPUB guide is ')
+      writer.println("<a href='${epub}'>version ${guideVersion}</a>.</p>")
+      writer.println('</body>')
+      writer.println('</html>')
+      writer.close()
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1217,6 +1217,7 @@ task webGuide(
   inputs.dir "${buildDir}/guide"
   outputs.dir "${buildDir}/website/guide/${guideVersion}"
   outputs.file "${buildDir}/website/guide/index.html"
+  outputs.file "${buildDir}/website/epub/index.html"
 
   doLast {
     copy {
@@ -1243,6 +1244,7 @@ task webGuide(
       writer.println('</html>')
       writer.close()
 
+      mkdir("${buildDir}/website/epub")
       def epub = "DocBook-xslTNG-${guideVersion}.epub"
       html = new File("${buildDir}/website/epub/index.html")
       writer = new PrintStream(html)

--- a/src/guide/resources/css/guide.css
+++ b/src/guide/resources/css/guide.css
@@ -145,10 +145,21 @@ img {
     text-align: center;
 }
 
-pre.border {
+/* screens always have a border */
+.screen,
+.border {
     border: 1px solid #afafaf;
     border-radius: 4px;
     width: 99%;
+}
+
+/* unnumbered listings are always monochrome ... */
+pre.verblines span.line:nth-child(even) {
+  background-color: var(--verbatim-odd-background-color);
+}
+
+pre.verblines.numbered span.line:nth-child(even) {
+  background-color: var(--verbatim-even-background-color);
 }
 
 @media only screen {
@@ -163,4 +174,28 @@ pre.border .line .ld {
 
 span.obsolete {
     text-decoration: line-through;
+}
+
+@page landscape {
+  size: landscape;
+}
+
+.landscape {
+  page: landscape;
+}
+
+.admonition {
+  break-inside: avoid;
+}
+
+.pre-wrap {
+    font-size: 10pt;
+}
+
+.screen {
+    break-inside: avoid;
+}
+
+p code {
+    white-space: nowrap;
 }

--- a/src/guide/xml/ch02.xml
+++ b/src/guide/xml/ch02.xml
@@ -414,7 +414,7 @@ a Docker-compatible, open source alternative that apparently doesn’t exhibit t
 <listitem>
 <para>Create a volume, say <replaceable>docbook-output</replaceable>,
 with the <code>docker volume</code> command.</para>
-<screen>docker volume create <replaceable>docbook-output</replaceable></screen>
+<screen role="monochrome border">docker volume create <replaceable>docbook-output</replaceable></screen>
 </listitem>
 <listitem>
 <para>Instead of mounting a directory on the local filesystem in the container, mount
@@ -427,28 +427,28 @@ the volume.</para>
 <para>In order to copy the files off the volume, the volume has to be
 mounted on a running container. You can start one with <code>docker run</code>,
 for example:</para>
-<screen>docker run —mount source=<replaceable>docbook-output</replaceable>,target=/out \
+<screen role="monochrome border">docker run —mount source=<replaceable>docbook-output</replaceable>,target=/out \
        --name copy-helper -d busyboxy sleep 3600</screen>
 </listitem>
 <listitem>
 <para>Copy the files out of the container. For a single file, <code>docker cp</code> will
 do the trick:</para>
-<screen>docker cp copy-helper:/out/<replaceable>filename.html</replaceable> .</screen>
+<screen role="monochrome border">docker cp copy-helper:/out/<replaceable>filename.html</replaceable> .</screen>
 <para>If there are multiple output files, you can copy them individually, or you can use 
 <code>docker exec</code>:</para>
-<screen>docker exec copy-helper \
+<screen role="monochrome border">docker exec copy-helper \
        /bin/sh -c 'cd /out &amp;&amp; tar cf - .' &gt; out.tar</screen>
 <para>That’ll copy all the files into the <filename>out.tar</filename> archive which you can
 expand wherever you like.</para>
 </listitem>
 <listitem>
 <para>When you have the files, you can stop and remove the container with:</para>
-<screen>docker stop copy-helper
+<screen role="monochrome border">docker stop copy-helper
 docker rm copy-helper</screen>
 </listitem>
 <listitem>
 <para>You may want to remove the volume you created as well:</para>
-<screen>docker volume rm docbook-output</screen>
+<screen role="monochrome border">docker volume rm docbook-output</screen>
 <para>and recreate it for the next transformation. If you don’t, be
 aware that the content of the volume will persist. If you resuse the
 volume for other transformations, the output from the various
@@ -571,7 +571,7 @@ Make sure that the <filename>docbook-xsltng-<replaceable>version</replaceable>.j
 file is on your class path and use the Saxon <code>-init</code> option to
 load them:</para>
 
-<screen><?db verbatim-style="plain"
+<screen role="monochrome border"><?db verbatim-style="plain"
 ?><userinput>-init:org.docbook.xsltng.extensions.Register</userinput></screen>
 
 <section xml:id="ext-debug">
@@ -757,7 +757,7 @@ document (part, chapter, article, section, etc.) becomes a page.</para>
 local storage to synchronize display in different browser windows.</para>
 
 <para>Add</para>
-<programlisting><![CDATA[<meta xmlns="http://www.w3.org/1999/xhtml"
+<programlisting linenumbering="unnumbered"><![CDATA[<meta xmlns="http://www.w3.org/1999/xhtml"
       name="localStorage.key" content="keyName"/>]]></programlisting>
 <para>to the <tag>info</tag> of your document.</para>
 
@@ -1189,8 +1189,9 @@ xrefstyle="%c"/>.</para>
 &lt;phrase outputformat=&quot;print&quot;&gt; 
   on &lt;xref linkend=&quot;syntax-highlighting&quot; xrefstyle=&quot;page %p&quot;/&gt;
 &lt;/phrase&gt;
-will reference the page number only when the @profile.outputformat parameter is print,
-but without the annoying # in HTML.</programlisting>
+will reference the page number only when the
+@profile.outputformat parameter is print, but
+without the annoying # in HTML.</programlisting>
     </example>
   </section>
 </section>

--- a/src/guide/xml/ch03.xml
+++ b/src/guide/xml/ch03.xml
@@ -776,7 +776,7 @@ xslTNG framework. <xref linkend="ex.schematron.glossary" xrefstyle="%label"/>, h
 shows how you could use schematron to check whether there is exactly one <tag>glossentry</tag>
 for the <tag>glossterm</tag> and <tag>firstterm</tag> elements in your document.</para>
 
-<example xml:id="ex.schematron.glossary">
+<example xml:id="ex.schematron.glossary" role="landscape">
   <title>A Schematron schema to check glossary terms</title>
   <programlistingco>
     <areaspec units="linecolumn">
@@ -959,7 +959,7 @@ processing by processing DocBook elements in the
 <para>Here is a simple example of a stylesheet that produces a JSON version of the
 Table of Contents for a DocBook document:</para>
 
-<programlisting language="xml"
+<programlisting language="xml landscape"
 ><xi:include href="examples/issue84.xsl" parse="text"/></programlisting>
 
 <note>

--- a/src/main/xslt/docbook-paged.xsl
+++ b/src/main/xslt/docbook-paged.xsl
@@ -18,6 +18,7 @@
 <xsl:param name="annotations" select="'inline'"/>
 <xsl:param name="xlink-style-default" select="'inline'"/>
 <xsl:param name="paper-size" select="'A4'"/>
+<xsl:param name="titleabbrev-passthrough" select="'false'"/>
 
 <!-- ============================================================ -->
 

--- a/src/website/html/homepage.html
+++ b/src/website/html/homepage.html
@@ -39,8 +39,8 @@ also supported.</p>
 
 <p>The current release is documented in the
 <a href="guide/index.html"><cite>DocBook: xslTNG Reference</cite>
-(<a href="/epub/DocBook-xslTNG-2.1.0.epub">EPUB</a>,
-<a href="/pdf/DocBook-xslTNG-2.1.0.pdf">PDF</a>).
+(<a href="/epub/">EPUB</a>,
+<a href="/pdf/DocBook-xslTNG-2.2.0.pdf">PDF</a>).
 </a></p>
 
 <!--


### PR DESCRIPTION
1. Make the EPUB link redirect to the most recent version
2. Update the PDF link
3. Various improvements to the PDF rendering, mostly in CSS, but also turn off `titleabbrev-passthrough` for PDF.
