### PR TITLE
Changed determination of label for biblioentry / bibliomixed

### DIFF
--- a/src/main/xslt/modules/xref.xsl
+++ b/src/main/xslt/modules/xref.xsl
@@ -146,10 +146,7 @@
 
 <xsl:template match="db:bibliomixed|db:biblioentry" mode="m:crossref-label">
   <xsl:choose>
-    <xsl:when test="node()[1]/self::db:abbrev
-                    or (node()[1]/text()
-                        and normalize-space(node()[1]) = ''
-                        and node()[2]/self::db:abbrev)">
+    <xsl:when test="*[1]/self::db:abbrev">
       <xsl:apply-templates select="db:abbrev[1]"/>
     </xsl:when>
     <xsl:when test="@xml:id">


### PR DESCRIPTION
Simplified (and corrected?) the test whether an entry in the bibliography has an `abbrev` element as it's first element node, that should be used as the entries label. 

See Issue #479 

