### PR TITLE
Initial implementation of partial support for copying media files

### DIFF
--- a/src/main/xslt/modules/chunk-output.xsl
+++ b/src/main/xslt/modules/chunk-output.xsl
@@ -215,7 +215,7 @@
 </xsl:function>
 
 <xsl:template match="element()">
-  <xsl:copy>
+  <xsl:copy copy-namespaces="no">
     <xsl:apply-templates select="@*,node()"/>
   </xsl:copy>
 </xsl:template>

--- a/src/main/xslt/modules/objects.xsl
+++ b/src/main/xslt/modules/objects.xsl
@@ -5,6 +5,7 @@
                 xmlns:ext="http://docbook.org/extensions/xslt"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
+                xmlns:ghost="http://docbook.org/ns/docbook/ephemeral"
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
@@ -757,6 +758,7 @@
     </xsl:when>
     <xsl:otherwise>
       <xsl:call-template name="t:mediaobject-img">
+        <xsl:with-param name="sourcefilename" select="$info?uri"/>
         <xsl:with-param name="filename" select="$info?href"/>
         <xsl:with-param name="styles" select="$styles"/>
         <xsl:with-param name="viewport" select="$viewport"/>
@@ -767,12 +769,13 @@
 </xsl:template>
 
 <xsl:template name="t:mediaobject-img">
+  <xsl:param name="sourcefilename" as="xs:string"/>
   <xsl:param name="filename" as="xs:string"/>
   <xsl:param name="styles" as="xs:string*"/>
   <xsl:param name="viewport" as="map(*)?"/>
   <xsl:param name="imageproperties" as="map(*)?"/>
 
-  <img src="{$filename}">
+  <img src="{$filename}" ghost:sourcefilename='{$sourcefilename}'>
     <xsl:apply-templates select="." mode="m:attributes"/>
     
     <!-- Apply any alt text in the media object to the image tag. -->


### PR DESCRIPTION
This is an suggestion how to support user when they have to copy media files from the DocBook Sources to the HTML Result file structure. I think that support for this would be very helpfull, since the destination file structury may differ from the source file structure. This initial implementation covers only images (DocBook elements that lead to an `html:img` element) and does not include any documentation in the reference manual.

The idea is that every `html:img` element gets an additional attribute `ghost:sourcefilename` with the full path of the original media file in  the docbook source file structure. This attribute is kept in all following transformations steps up to, and including, post processing.

The value of  `img/@src` attribute is relative to the HTML file which includes the `img` element. When we know the `$mediaobject-base-output-uri` we can resolve the `@src` attribute against it to get an absolute value. The same should be possible with chunked output, but this is not implemented yet. When there are to absolute file-paths, we can generate **copy-instructions**, since we know source and destination.
    
If the function `file:copy` is available, the copy instructions can be executed. This is the case for users with a licence of SAXON-PE or EE including Users with Oxygen.  Otherwise, a file with copy instructions could be generated (this is not implemented, since there is a conflict with the XSpec based test mechanism: _Can't do `result-document` while evaluating as variable._).

In don't  expect this PR to be merged into the Stylesheets, because it's  incomplete. If you think the basic idea works, I would develop the proposal further.

Greetings, Frank
