### PR TITLE
Add tunnel-parameter for base uris in mode chunk-cleanup in print.xsl

### DIFF
--- a/src/main/xslt/docbook-paged.xsl
+++ b/src/main/xslt/docbook-paged.xsl
@@ -93,7 +93,10 @@
     <xsl:variable name="ctype" select="$head/h:meta[@http-equiv='Content-Type']"/>
     <xsl:variable name="title" select="$head/h:title"/>
     <head>
-      <xsl:apply-templates select="$ctype" mode="m:chunk-cleanup"/>
+        <xsl:apply-templates select="$ctype" mode="m:chunk-cleanup">
+          <xsl:with-param name="rootbaseuri" select="$rbu"/>
+          <xsl:with-param name="chunkbaseuri" select="$cbu"/>
+        </xsl:apply-templates>
       <title>
         <xsl:value-of select="f:chunk-title(.)"/>
       </title>
@@ -101,26 +104,26 @@
         <xsl:text>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})</xsl:text>
         <xsl:text>(document.documentElement)</xsl:text>
       </script>
-      <xsl:apply-templates select="$head/node() except ($ctype|$title)"
-                           mode="m:chunk-cleanup">
-        <xsl:with-param name="rootbaseuri" select="$rbu"/>
-        <xsl:with-param name="chunkbaseuri" select="$cbu"/>
-      </xsl:apply-templates>
-      <xsl:if test="exists(.//mml:*)"
-              xmlns:mml="http://www.w3.org/1998/Math/MathML">
-        <xsl:apply-templates select="/h:html/h:db-mathml-script/*"
-                             mode="m:chunk-cleanup">
+        <xsl:apply-templates select="$head/node() except ($ctype | $title)" mode="m:chunk-cleanup">
           <xsl:with-param name="rootbaseuri" select="$rbu"/>
           <xsl:with-param name="chunkbaseuri" select="$cbu"/>
         </xsl:apply-templates>
+      <xsl:if test="exists(.//mml:*)"
+              xmlns:mml="http://www.w3.org/1998/Math/MathML">
+          <xsl:apply-templates select="/h:html/h:db-mathml-script/*" mode="m:chunk-cleanup">
+            <xsl:with-param name="rootbaseuri" select="$rbu"/>
+            <xsl:with-param name="chunkbaseuri" select="$cbu"/>
+          </xsl:apply-templates>
       </xsl:if>
     </head>
     <body>
       <xsl:copy-of select="*/@*"/>
       <xsl:apply-templates select="*/h:header" mode="m:chunk-cleanup"/>
       <main>
-        <xsl:apply-templates select="*/* except */h:header"
-                             mode="m:chunk-cleanup"/>
+          <xsl:apply-templates select="*/* except */h:header" mode="m:chunk-cleanup">
+            <xsl:with-param name="rootbaseuri" select="$rbu" tunnel="yes"/>
+            <xsl:with-param name="chunkbaseuri" select="$cbu" tunnel="yes"/>
+          </xsl:apply-templates>
       </main>
     </body>
   </html>


### PR DESCRIPTION
See Issue #484  Adds necessary parameters for template calls in mode `chunk-cleanup` in the `print.xsl` stylesheet. 

This allows _fake chunking_ for paged media, which is basically to produce one single HTML file at a location that is known to, and controlled by, the stylesheet in form of `$chunk-output-base-uri` and `$chunk`. This, in turn, enables the stylesheets to produce (and execute, if the `file:copy` function is available) copy instructions for media files, since the absolute path for the destination can be calculated. 

It was not clear to me where i had to use the `tunnel="yes"` declaration. My first guess was to use it for every template parameter `rootbaseuri` and `chunkbaseuri`, but that leads to errors. The current solution is the result of trial-and-error.

Greetings, Frank 