### PR TITLE
Issue 484 Add tunnel parameters in call-template in mode chunk-cleanup

### DIFF
--- a/src/main/xslt/docbook-paged.xsl
+++ b/src/main/xslt/docbook-paged.xsl
@@ -117,10 +117,16 @@
     </head>
     <body>
       <xsl:copy-of select="*/@*"/>
-      <xsl:apply-templates select="*/h:header" mode="m:chunk-cleanup"/>
+      <xsl:apply-templates select="*/h:header" mode="m:chunk-cleanup">
+        <xsl:with-param name="rootbaseuri" select="$rbu" tunnel="yes"/>
+        <xsl:with-param name="chunkbaseuri" select="$cbu" tunnel="yes"/>
+      </xsl:apply-templates>
       <main>
         <xsl:apply-templates select="*/* except */h:header"
-                             mode="m:chunk-cleanup"/>
+                             mode="m:chunk-cleanup">
+          <xsl:with-param name="rootbaseuri" select="$rbu" tunnel="yes"/>
+          <xsl:with-param name="chunkbaseuri" select="$cbu" tunnel="yes"/>
+        </xsl:apply-templates>
       </main>
     </body>
   </html>


### PR DESCRIPTION
Add tunnel parameters for base uri of root document and chunked documents in `docbook-paged.xsl`, so that chunk works when transformation is done via `print.xsl`.

The intended use case is fake chunking with `$chunk-include='()'`. The reason is explained in Issue #484. I need to know the filepath of the html result document to generate copy instructions for mediaobjects.

Greetings, Frank