### PR TITLE
Issue 482 Support executable copy instructions for image objects

### DIFF
--- a/src/main/xslt/docbook.xsl
+++ b/src/main/xslt/docbook.xsl
@@ -5,7 +5,9 @@
                 xmlns:err='http://www.w3.org/2005/xqt-errors'
                 xmlns:ext="http://docbook.org/extensions/xslt"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
+                xmlns:file="http://expath.org/ns/file"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
+                xmlns:ghost="http://docbook.org/ns/docbook/ephemeral"
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:mp="http://docbook.org/ns/docbook/modes/private"
@@ -275,7 +277,15 @@
   <xsl:variable name="result" as="document-node()">
     <xsl:sequence select="fp:run-transforms($result, $post-processing)"/>
   </xsl:variable>
-
+  
+  <xsl:call-template name="tp:mediaobjects-copy-support">
+    <xsl:with-param name="html" select="$result"/>
+  </xsl:call-template>
+  
+  <xsl:variable name="result" as="document-node()">
+    <xsl:apply-templates select="$result" mode="mp:final-cleanup"/>
+  </xsl:variable>
+  
   <xsl:choose>
     <xsl:when test="$return = 'raw-results'">
       <xsl:sequence select="map {
@@ -448,5 +458,71 @@
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>
+  
+<!-- Try to copy mediaobject files if a copy function is available, and if there is an absolute output base uri -->
+<xsl:template name="tp:mediaobjects-copy-support" use-when="function-available('file:copy')">
+  <xsl:param name="html" as="document-node()"/>
+  <xsl:choose>
+    <xsl:when test="$vp:chunk-output-base-uri or $mediaobject-output-base-uri">
+      <xsl:for-each select="$html//h:img[@ghost:sourcefile]">
+        <xsl:variable name="copy-instruction" as="map(*)?">
+          <xsl:apply-templates select="." mode="mp:mediaobject-copy-instruction"/>
+        </xsl:variable>
+        <xsl:try>
+          <xsl:choose>
+            <xsl:when test="not(exists($copy-instruction))"/>
+            <xsl:when test="file:exists($copy-instruction('source'))">
+              <xsl:sequence
+                select="file:copy($copy-instruction('source'), $copy-instruction('destination'))"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:message
+                select="'Can''t copy ' || $copy-instruction('source') || ': file not found.'"/>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:catch>
+            <xsl:message
+              select="'Can''t copy ' || $copy-instruction('source') || ': ' || $err:description"/>
+          </xsl:catch>
+        </xsl:try>
+      </xsl:for-each>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:message select="'Can''t copy media objects: output base uri not set.'"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template name="tp:mediaobjects-copy-support" use-when="not(function-available('file:copy'))">
+  <xsl:param name="html" as="document-node()"/>
+  <!-- NO OP -->
+</xsl:template>
+
+<!-- mp:mediaobject-copy-instruction calculates for some HTML Elements a map which can support copy instructions  -->
+<xsl:mode name="mp:mediaobject-copy-instruction" on-no-match="fail"/>
+
+<xsl:template match="h:img" mode="mp:mediaobject-copy-instruction" as="map(*)?">
+  <xsl:choose>
+    <xsl:when test="$mediaobject-output-base-uri">
+      <xsl:sequence select="
+        map {
+        'source': @ghost:sourcefile,
+        'destination': resolve-uri(@src, $mediaobject-output-base-uri)
+        }"/>
+    </xsl:when>
+    <xsl:when test="$chunk-output-base-uri">
+      <xsl:sequence select="
+        map {
+        'source': @ghost:sourcefile,
+        'destination': resolve-uri(@src, $chunk-output-base-uri)
+        }"/>
+    </xsl:when>
+  </xsl:choose>
+</xsl:template>
+
+<!-- mp:final-cleanup removes attributes in the ghost namespace -->
+<xsl:mode name="mp:final-cleanup" on-no-match="shallow-copy"/>
+
+<xsl:template mode="mp:final-cleanup" match="@ghost:*"/>
 
 </xsl:stylesheet>

--- a/src/main/xslt/modules/chunk-output.xsl
+++ b/src/main/xslt/modules/chunk-output.xsl
@@ -215,7 +215,7 @@
 </xsl:function>
 
 <xsl:template match="element()">
-  <xsl:copy>
+  <xsl:copy copy-namespaces="no">
     <xsl:apply-templates select="@*,node()"/>
   </xsl:copy>
 </xsl:template>

--- a/src/main/xslt/modules/objects.xsl
+++ b/src/main/xslt/modules/objects.xsl
@@ -5,6 +5,7 @@
                 xmlns:ext="http://docbook.org/extensions/xslt"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
+                xmlns:ghost="http://docbook.org/ns/docbook/ephemeral"
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
@@ -757,6 +758,7 @@
     </xsl:when>
     <xsl:otherwise>
       <xsl:call-template name="t:mediaobject-img">
+        <xsl:with-param name="sourcefile" select="$info?uri"/>
         <xsl:with-param name="filename" select="$info?href"/>
         <xsl:with-param name="styles" select="$styles"/>
         <xsl:with-param name="viewport" select="$viewport"/>
@@ -767,12 +769,13 @@
 </xsl:template>
 
 <xsl:template name="t:mediaobject-img">
+  <xsl:param name="sourcefile" as="xs:string"/>
   <xsl:param name="filename" as="xs:string"/>
   <xsl:param name="styles" as="xs:string*"/>
   <xsl:param name="viewport" as="map(*)?"/>
   <xsl:param name="imageproperties" as="map(*)?"/>
 
-  <img src="{$filename}">
+  <img src="{$filename}" ghost:sourcefile='{$sourcefile}'>
     <xsl:apply-templates select="." mode="m:attributes"/>
     
     <!-- Apply any alt text in the media object to the image tag. -->


### PR DESCRIPTION
Although copying of media objects is "not our problem" we should help the users of the stylesheets.

A precondition is that we know the filepath of the generated HTML file(s). This is the case when we do chunking (`$cunk-output-base-uri`). 

I suggest to introduce a new attribute `ghost:sourcefile` for html elements for mediaobjects. I did it only for images, because i don't know if you like this approach.

With this new attribute, we can

- generate executable copy instructions and execute them in the stylesheets. This is maximum support, but needs a function `file:copy`. Needs Saxon PE or EE Edition or a alternative implementation of `expath:file`. Works for users of Oxygen (Saxon EE included).
- generate an external file with copy instructions (maybe a shell script). Not included in this PR, because `result-document` conflicted with XSpec.

Greetings, Frank