### PR TITLE
Issue 486 Inherit @lang Attribute in HTML chunks

### DIFF
--- a/src/main/xslt/modules/chunk-cleanup.xsl
+++ b/src/main/xslt/modules/chunk-cleanup.xsl
@@ -198,6 +198,13 @@
     <xsl:if test="normalize-space($default-theme) ne ''">
       <xsl:attribute name="class" select="$default-theme"/>
     </xsl:if>
+    
+    <!-- inherit lang attribute -->
+    <xsl:variable name="lang" as="attribute(lang)?" select="(ancestor::*/@lang)[last()]"/>
+    <xsl:if test="not(@lang)">
+      <xsl:copy-of select="$lang"/>
+    </xsl:if>
+    
     <head>
       <!-- When serialized, this always comes first, so make sure it's first
            here. (It doesn't really matter in practice, but the XSpec tests


### PR DESCRIPTION
Adds an inherited `html/@lang` attribute for chunks. See Issue #486.

I am not sure where it should be placed: `html/@lang` or `main/@lang` or `article/@lang` or ...? I decided to do it in `html/@lang` because [Declaring language in HTML](https://www.w3.org/International/questions/qa-html-language-declarations.en) from W3C says so.  

Greetings, Frank