### PR TITLE
Extend the recent vendor-css hook to support Weasyprint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -781,7 +781,8 @@ task compileSass() {
         "${fProjectDir}/src/main/scss/docbook-epub.scss:${buildDir}/css/docbook-epub.css",
         "${fProjectDir}/src/main/scss/toc.scss:${buildDir}/css/docbook-toc.css",
         "${fProjectDir}/src/main/scss/vendor-ahf-portrait.scss:${buildDir}/css/vendor-ahf-portrait.css",
-        "${fProjectDir}/src/main/scss/vendor-ahf-landscape.scss:${buildDir}/css/vendor-ahf-landscape.css"
+        "${fProjectDir}/src/main/scss/vendor-ahf-landscape.scss:${buildDir}/css/vendor-ahf-landscape.css",
+        "${fProjectDir}/src/main/scss/vendor-weasyprint.scss:${buildDir}/css/vendor-weasyprint.css"
     }
   }
 
@@ -794,13 +795,14 @@ task compileSass() {
         "${fProjectDir}/src/main/scss/docbook-epub.scss:${buildDir}/css/docbook-epub.min.css",
         "${fProjectDir}/src/main/scss/toc.scss:${buildDir}/css/docbook-toc.min.css",
         "${fProjectDir}/src/main/scss/vendor-ahf-portrait.scss:${buildDir}/css/vendor-ahf-portrait.min.css",
-        "${fProjectDir}/src/main/scss/vendor-ahf-landscape.scss:${buildDir}/css/vendor-ahf-landscape.min.css"
+        "${fProjectDir}/src/main/scss/vendor-ahf-landscape.scss:${buildDir}/css/vendor-ahf-landscape.min.css",
+        "${fProjectDir}/src/main/scss/vendor-weasyprint.scss:${buildDir}/css/vendor-weasyprint.min.css"
     }
   }
 
   doLast {
     ["docbook", "docbook-paged", "docbook-epub", "docbook-toc",
-     "vendor-ahf-landscape", "vendor-ahf-portrait"].each { base ->
+     "vendor-ahf-landscape", "vendor-ahf-portrait", "vendor-weasyprint"].each { base ->
       [".css", ".min.css"].each { ext ->
         String fn = "${base}${ext}"
         File css = new File("${buildDir}/css/${fn}")
@@ -1181,6 +1183,15 @@ if (pdftool == "prince") {
     commandLine "${vivliostyle}",
       "build", "${buildDir}/guide/guide.pdf.html",
       "-o", "${buildDir}/guide/guide.pdf"
+  }
+} else if (pdftool == "weasyprint") {
+  task "guide.pdf"(type: Exec, dependsOn: ["guide.pdf.html"]) {
+    inputs.file("${buildDir}/guide/guide.pdf.html")
+    inputs.files fileTree(dir: "${buildDir}/guide/css")
+    outputs.file("${buildDir}/guide/guide.pdf")
+    commandLine "${weasyprint}",
+      "${buildDir}/guide/guide.pdf.html",
+      "${buildDir}/guide/guide.pdf"
   }
 } else {
   throw new GradleException("Unknown pdftool: " + pdftool)

--- a/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestCase.groovy
+++ b/buildSrc/src/main/groovy/org/docbook/xsltng/gradle/TestCase.groovy
@@ -276,6 +276,32 @@ class TestCase {
             "-o", "${project.projectDir}/src/test/resources/expectedpdf/${pdfTool}/${testname}.pdf"
         }
         break
+
+      case "weasyprint":
+        //println("Register ${testname}.pdf (${pdfTool})")
+        project.tasks.register("${testname}.pdf", Exec) {
+          inputs.files project.fileTree(dir: "${project.buildDir}/actual/css")
+          inputs.file project.file("${project.buildDir}/actual/${testname}.pdf.html")
+          outputs.file project.file("${project.buildDir}/actual/${testname}.pdf")
+          dependsOn pdfhtml
+
+          commandLine pdfExec,
+            "${project.buildDir}/actual/${testname}.pdf.html",
+            "${project.buildDir}/actual/${testname}.pdf"
+        }
+
+        //println("Register ${testname}.pdf.expected (${pdfTool})")
+        project.tasks.register("${testname}.pdf.expected", Exec) {
+          inputs.files project.fileTree(dir: "${project.buildDir}/actual/css")
+          inputs.file project.file("${project.buildDir}/actual/${testname}.pdf.html")
+          outputs.file project.file("${project.projectDir}/src/test/resources/expectedpdf/${pdfTool}/${testname}.pdf")
+          dependsOn pdfhtml
+
+          commandLine pdfExec,
+            "${project.buildDir}/actual/${testname}.pdf.html",
+            "${project.projectDir}/src/test/resources/expectedpdf/${pdfTool}/${testname}.pdf"
+        }
+        break
       case null:
         println("No PDF tool configured, skipping PDF tests")
         break

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ pdftool=antennahouse
 antennahouse=/usr/local/AHFormatterV74/bin/AHFCmd
 prince=/usr/local/bin/prince
 vivliostyle=/usr/local/bin/vivliostyle
+weasyprint=/opt/homebrew/bin/weasyprint
 
 # Properties for arbitrary transformations
 dbsource=

--- a/src/guide/xml/changelog.xml
+++ b/src/guide/xml/changelog.xml
@@ -45,7 +45,12 @@ development continues.</para>
   This change is a consequence of how Saxon initializes the XML Resolver.
   </para>
 </listitem>
-
+<listitem>
+  <para>Added a <filename>vendor-weasyprint.css</filename> stylesheet for use with
+  the <parameter>vendor-css</parameter> parameter;
+  fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/497">#497</link>.
+  </para>
+</listitem>
 </itemizedlist>
 </section>
 

--- a/src/main/scss/page-setup.scss
+++ b/src/main/scss/page-setup.scss
@@ -366,8 +366,16 @@ html.book-style.Letter {
 
     html.article-style.#{$pagesize} body.draft.portrait {
         string-set: DocumentTitle "";
-        page: #{$pagesize}-article-flow-draft-portrait;
+        page: #{$pagesize}-article-flow-portrait-draft;
     }
+    html.article-style.#{$pagesize} body.draft.portrait,
+    html.article-style.#{$pagesize} body.draft.portrait .db-bfs,
+    html.article-style.#{$pagesize} body.draft.portrait .division,
+    html.article-style.#{$pagesize} body.draft.portrait .component,
+    html.article-style.#{$pagesize} body.draft.portrait .section,
+    html.article-style.#{$pagesize} body.draft.portrait .formalobject,
+    html.article-style.#{$pagesize} body.draft.portrait .informalobject,
+    html.article-style.#{$pagesize} body.draft.portrait .list-of-titles,
     html.article-style.#{$pagesize} body .db-bfs.draft.portrait,
     html.article-style.#{$pagesize} body .division.draft.portrait,
     html.article-style.#{$pagesize} body .component.draft.portrait,
@@ -375,12 +383,12 @@ html.book-style.Letter {
     html.article-style.#{$pagesize} body .formalobject.draft.portrait,
     html.article-style.#{$pagesize} body .informalobject.draft.portrait,
     html.article-style.#{$pagesize} body .list-of-titles.draft.portrait {
-        page: #{$pagesize}-article-flow-draft-portrait;
+        page: #{$pagesize}-article-flow-portrait-draft;
     }
 
     html.article-style.#{$pagesize} body.draft.landscape {
         string-set: DocumentTitle "";
-        page: #{$pagesize}-article-flow-draft-landscape;
+        page: #{$pagesize}-article-flow-landscape-draft;
     }
     html.article-style.#{$pagesize} body .db-bfs.draft.landscape,
     html.article-style.#{$pagesize} body .division.draft.landscape,
@@ -389,7 +397,7 @@ html.book-style.Letter {
     html.article-style.#{$pagesize} body .formalobject.draft.landscape,
     html.article-style.#{$pagesize} body .informalobject.draft.landscape,
     html.article-style.#{$pagesize} body .list-of-titles.draft.landscape {
-        page: #{$pagesize}-article-flow-draft-landscape;
+        page: #{$pagesize}-article-flow-landscape-draft;
     }
 }
 
@@ -405,6 +413,7 @@ html.book-style.Letter {
     html.book-style.#{$pagesize} body .component,
     html.book-style.#{$pagesize} body .list-of-titles {
         break-before: right;
+        page: #{$pagesize}-book-flow-portrait;
     }
 
     html.book-style.#{$pagesize} body .division.portrait,
@@ -436,50 +445,44 @@ html.book-style.Letter {
     }
 
     html.book-style.#{$pagesize} body.draft.portrait {
-        page: #{$pagesize}-book-title-flow-draft-portrait;
+        page: #{$pagesize}-book-title-flow-portrait-draft;
     }
+    html.book-style.#{$pagesize} body.draft,
+    html.book-style.#{$pagesize} body.draft.portrait,
+    html.book-style.#{$pagesize} body.draft.portrait .division,
+    html.book-style.#{$pagesize} body.draft.portrait .component,
+    html.book-style.#{$pagesize} body.draft.portrait .list-of-titles,
+    html.book-style.#{$pagesize} body.portrait .division.draft,
+    html.book-style.#{$pagesize} body.portrait .component.draft,
+    html.book-style.#{$pagesize} body.portrait .list-of-titles.draft,
     html.book-style.#{$pagesize} body .division.draft.portrait,
     html.book-style.#{$pagesize} body .component.draft.portrait,
     html.book-style.#{$pagesize} body .list-of-titles.draft.portrait {
         break-before: right;
-        page: #{$pagesize}-book-flow-draft-portrait;
+        page: #{$pagesize}-book-flow-portrait-draft;
     }
     html.book-style.#{$pagesize} body .section.draft.portrait,
     html.book-style.#{$pagesize} body .formalobject.draft.portrait,
     html.book-style.#{$pagesize} body .informalobject.draft.portrait {
-        page: #{$pagesize}-book-flow-draft-portrait;
+        page: #{$pagesize}-book-flow-portrait-draft;
     }
     html.book-style.#{$pagesize} body.draft.landscape {
-        page: #{$pagesize}-book-title-draft-landscape;
+        page: #{$pagesize}-book-title-landscape-draft;
     }
     html.book-style.#{$pagesize} body .division.draft.landscape,
     html.book-style.#{$pagesize} body .component.draft.landscape,
     html.book-style.#{$pagesize} body .list-of-titles.draft.landscape {
         break-before: right;
-        page: #{$pagesize}-book-draft-landscape;
+        page: #{$pagesize}-book-landscape-draft;
     }
     html.book-style.#{$pagesize} body .section.draft.landscape,
     html.book-style.#{$pagesize} body .formalobject.draft.landscape,
     html.book-style.#{$pagesize} body .informalobject.draft.landscape {
-        page: #{$pagesize}-book-draft-landscape;
+        page: #{$pagesize}-book-landscape-draft;
     }
 }
 
 /* ============================================================ */
-
-/*
-html.article-style > header {
-    page-break-after: always;
-}
-
-html.article-style .list-of-titles {
-    break-before: always;
-}
-
-.article-style .division {
-    break-before: always;
-}
-*/
 
 html.article-style .list-of-titles div .title {
     string-set: ComponentTitle content()

--- a/src/main/scss/vendor-weasyprint.scss
+++ b/src/main/scss/vendor-weasyprint.scss
@@ -1,0 +1,52 @@
+.division body > header .copyright {
+    float: inherit;
+}
+
+@page {
+    @footnote {
+        float: inherit;
+        border-top: thin solid black;
+        border-length: inherit;
+        padding-top: 0.5em;
+    }
+}
+
+@each $pagesize in [A4, A5, Letter] {
+    html.book-style.#{$pagesize} body .list-of-titles {
+        counter-reset: none;
+    }
+
+    @each $orient in [portrait, landscape] {
+        @each $draft in [draft] {
+            $dlabel: "-draft";
+
+            @page #{$pagesize}-book-title-flow-#{$orient}#{$dlabel} {
+                background-position: top right;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:right {
+                background-position: top right;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:right:first {
+                background-position: top right;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:right:blank {
+                background-position: top right;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:left {
+                background-position: top left;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:left:first {
+                background-position: top left;
+            }
+
+            @page #{$pagesize}-book-flow-#{$orient}#{$dlabel}:left:blank {
+                background-position: top left;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #497 

The `vendor-weasyprint.css` stylesheet works around some of the difficulties with weasyprint.

There's also an incomplete fix for #522 in here.