### PR TITLE
Fix copy-and-paste error

### DIFF
--- a/src/guide/xml/ref-functions.xml
+++ b/src/guide/xml/ref-functions.xml
@@ -2278,7 +2278,7 @@ descendants. The options “<literal>fixup-xml-base</literal>” and
 </refmeta>
 <refnamediv>
 <refname>ext:validate-with-relax-ng</refname>
-<refpurpose>Returns the current working directory</refpurpose>
+<refpurpose>Validates with RELAX NG</refpurpose>
 <refclass>function</refclass>
 </refnamediv>
 <refsynopsisdiv>


### PR DESCRIPTION
No, @cmsmcq, `validate-with-relax-ng()` does not really return the current working directory.

R.I.P., my friend. 😭 😭 😭 

Fix #499 
