### PR TITLE
check refentry-generate-name, remove refentry-generate-title

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -3554,35 +3554,7 @@ the provided grammar.
 <title>Description</title>
 <para>If <parameter>refentry-generate-name</parameter> is true, the
 title of the refentry page will be the word “Name”. Otherwise it will
-be the title of the subject of the reference page. Generally, exactly one
-of <parameter>refentry-generate-name</parameter> or
-<parameter>refentry-generate-title</parameter> should
-<glossterm baseform="is true">be true</glossterm>.
-</para>
-</refsection>
-</refentry>
-
-<refentry>
-  <refmeta>
-    <fieldsynopsis>
-      <varname>refentry-generate-title</varname>
-      <initializer>true()</initializer>
-    </fieldsynopsis>
-  </refmeta>
-  <refnamediv>
-    <refpurpose>Use the subject of the page as the title of a <tag>refentry</tag>
-    </refpurpose>
-  </refnamediv>
-<refsection>
-<title>Description</title>
-<para>If <parameter>refentry-generate-title</parameter> is true, the
-title of the refentry page will be the subject of the page (the
-<tag>refentrytitle</tag>, <tag>refdescriptor</tag>, or the first
-<tag>refname</tag>). Generally, exactly one
-of <parameter>refentry-generate-name</parameter> or
-<parameter>refentry-generate-title</parameter> should
-<glossterm baseform="is true">be true</glossterm>.
-</para>
+be the title of the subject of the reference page.</para>
 </refsection>
 </refentry>
 

--- a/src/main/xslt/modules/refentry.xsl
+++ b/src/main/xslt/modules/refentry.xsl
@@ -31,7 +31,7 @@
     <xsl:apply-templates select="." mode="m:attributes"/>
 
     <xsl:choose>
-      <xsl:when test="$refentry-generate-name">
+      <xsl:when test="f:is-true($refentry-generate-name)">
         <header>
           <h2>
             <xsl:apply-templates select="." mode="m:gentext">
@@ -42,7 +42,7 @@
         </header>
       </xsl:when>
 
-      <xsl:when test="$refentry-generate-title">
+      <xsl:otherwise>
         <header>
           <h2>
             <xsl:choose>
@@ -58,7 +58,7 @@
             </xsl:choose>
           </h2>
         </header>
-      </xsl:when>
+      </xsl:otherwise>
     </xsl:choose>
 
     <p>


### PR DESCRIPTION
See #568  If  `$refentry-generate-name`  is true set title to "Name" otherwise use name of refentry