### PR TITLE
docbook.py: It's not about the performance, it's about the style.

### DIFF
--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -599,7 +599,6 @@ wrapper sets these automatically.
 
 if __name__ == "__main__":
     # I'm perfectly happy with the name 'docbook'
-    # pylint: disable=C0103
 
     try:
         docbook = JavaClassRunner(sys.argv[1:])

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -157,7 +157,7 @@ class JavaClassRunner:
 
         if resources is not None:
             if resources == "" and not self.output:
-                self._message(f"Cannot determine output directory; ignoring --resources")
+                self._message("Cannot determine output directory; ignoring --resources")
             else:
                 if resources == "":
                     resources = os.path.abspath(self.output)

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -28,7 +28,7 @@ class JavaClassRunner:
     # Yes, I have a lot of instance attributes. I'm also using camelCase names,
     # which aren't the Pythonic way, but they are the POM way. And I know some
     # methods could be functions.
-    # pylint: disable=R0902,C0103
+    # pylint: disable=R0902,C0103,W1514
 
     def __init__(self, args):
         self.version = "@@VERSION@@"

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -391,7 +391,7 @@ wrapper sets these automatically.
               or artifact not in self.depends[group] \
               or version not in self.depends[group][artifact] \
               or self.depends[group][artifact][version] is None:
-                found = self._libfallback(package);
+                found = self._libfallback(package)
 
         if not found:
             sys.exit(1)
@@ -479,8 +479,8 @@ wrapper sets these automatically.
                 if self._higher_version(curver, version):
                     usever = version
                     # Actually remove the current version, we're replacing it.
-                    del self._cp[group][artifact][curver];
-                    del self.depends[group][artifact][curver];
+                    del self._cp[group][artifact][curver]
+                    del self.depends[group][artifact][curver]
                 else:
                     usever = curver
 

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -526,6 +526,7 @@ wrapper sets these automatically.
             for path in os.environ["CLASSPATH"].split(os.pathsep):
                 cplist.append(path)
 
+        # pylint: disable=C0206
         for group in self._cp:
             for archive in self._cp[group]:
                 for version in self._cp[group][archive]:

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -310,9 +310,7 @@ wrapper sets these automatically.
             self._message(f"No jar: {groupId}:{artifactId}:{version}")
             return
 
-        pkgconfig = {}
-        pkgconfig["jar"] = jar
-        pkgconfig["dependencies"] = []
+        pkgconfig = {"jar": jar, "dependencies": []}
         self.depends[groupId][artifactId][version] = pkgconfig
 
         if self._skip(groupId, artifactId, version):

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -166,7 +166,8 @@ class JavaClassRunner:
                     resources = os.path.abspath(resources)
                 self._configure_resources(resources)
 
-    def _help(self):
+    @staticmethod
+    def _help():
         print(f"""DocBook xslTNG version @@VERSION@@
 
 Usage: {sys.argv[0]} [options]
@@ -263,7 +264,8 @@ wrapper sets these automatically.
         except IOError:
             return None
 
-    def _get_value(self, node, tag):
+    @staticmethod
+    def _get_value(node, tag):
         for child in node.childNodes:
             if child.nodeType == Node.ELEMENT_NODE \
               and child.tagName == tag \
@@ -280,7 +282,8 @@ wrapper sets these automatically.
             return jarfile
         return None
 
-    def _skip(self, groupId, artifactId, version):
+    @staticmethod
+    def _skip(groupId, artifactId, version):
         return (groupId is None or "${" in groupId
                 or artifactId is None or "${" in artifactId
                 or version is None or "${" in version)
@@ -364,7 +367,8 @@ wrapper sets these automatically.
 
         return deps
 
-    def _expandProperties(self, value, properties):
+    @staticmethod
+    def _expandProperties(value, properties):
         for prop in properties:
             repl = "${" + prop + "}"
             if repl in value:
@@ -405,7 +409,8 @@ wrapper sets these automatically.
         print(f"Required package not found: {group}:{artifact}:{version}; download with Maven")
         return False
 
-    def _higher_version(self, curver, newver):
+    @staticmethod
+    def _higher_version(curver, newver):
         if curver == newver:
             return False
 

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -237,7 +237,7 @@ wrapper sets these automatically.
             try:
                 if not os.path.isdir(fdir):
                     os.makedirs(fdir)
-            except:
+            except OSError:
                 self._message(f"Failed to create output directory: {path}")
                 return
 

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -41,7 +41,7 @@ class JavaClassRunner:
         # docbook-xslTNG package from the distribution environment and
         # we seed with its dependencies. These must all be in the
         # DocBook distribution (in libs/lib).
-        self.seeds = set(["@@PACKAGE_LIST@@"])
+        self.seeds = {"@@PACKAGE_LIST@@"}
 
         self.config = {
             "maven-local": str(Path.home()) + "/.m2/repository",

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -160,7 +160,7 @@ class JavaClassRunner:
                 self._message("Cannot determine output directory; ignoring --resources")
             else:
                 if resources == "":
-                    resources = os.path.abspath(self.output)
+                    resources = os.path.abspath(f"{self.output}")
                     resources = os.path.dirname(resources)
                 else:
                     resources = os.path.abspath(resources)

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -28,7 +28,7 @@ class JavaClassRunner:
     # Yes, I have a lot of instance attributes. I'm also using camelCase names,
     # which aren't the Pythonic way, but they are the POM way. And I know some
     # methods could be functions.
-    # pylint: disable=R0902,C0103,R0201
+    # pylint: disable=R0902,C0103
 
     def __init__(self, args):
         self.version = "@@VERSION@@"

--- a/src/bin/docbook.py
+++ b/src/bin/docbook.py
@@ -15,7 +15,6 @@ from xml.dom.minidom import parse, Node
 
 class JavaClassRunnerException(Exception):
     """Subclass of Exception for errors raised by the runner."""
-    pass
 
 
 class JavaClassRunner:


### PR DESCRIPTION
> Disclaimer: The proposed modifications do not improve performance or address any issues, but merely make the code more Pythonish and hopefully less prone to errors. The code has been checked to make sure it follows PEP 8 as well as the latest versions of Python 3 and pylint. To preserve the coding style and preferences of the original author, certain pylint warnings and suggestions have been intentionally muted (disabled checks).

* Removed `pass` (introduced by #505) that is no longer needed since #540 solved the original problem.
* Removed unnecessary semicolons (W0301 - unnecessary-semicolon).
* Removed unnecessary C0103 (invalid-name) check already specified at the class level.
* Removed now optional (since version 2.14) pylint check R0201 (no-self-use).
* Disabled W1514 (unspecified-encoding) check for open without explicitly specifying an encoding.
* Disabled C0206 (consider-using-dict-items) check for jar files iteration.
* Specified exception type `OSError` for `os.makedirs` (W0702 - bare-except). In an unlikely event of an illegal path, `os.path.isdir` might raise `ValueError`.
* Changed an f-string that does not use any interpolation variables to a regular string (W1309 - f-string-without-interpolation).
* Formatted `os.path.abspath` argument with an f-string to ensure its type.
* Replaced function call with set literal.
* Replaced dictionary creation with a dictionary literal.
* Declared static methods (plain functions) with the `@staticmethod` decorator.