### PR TITLE
Attributes in a non default namespace cause an error

### DIFF
--- a/src/main/xslt/modules/functions.xsl
+++ b/src/main/xslt/modules/functions.xsl
@@ -62,11 +62,12 @@
   <xsl:variable name="names"
                 select="distinct-values($attributes/node-name())"/>
   <xsl:for-each select="$names">
+    <xsl:variable name="namespace" select="namespace-uri-from-QName(.)"/>
     <xsl:variable name="name" select="."/>
     <xsl:variable name="values" as="xs:string*"
                   select="$attributes[node-name()=$name]/string()"/>
     <xsl:if test="exists($values)">
-      <xsl:attribute name="{$name}"
+      <xsl:attribute name="{$name}" namespace="{$namespace}"
                      select="string-join($values, ' ')"/>
     </xsl:if>
   </xsl:for-each>


### PR DESCRIPTION
Copy the attribute namespace. If the input document contains attributes in a custom namespace, functions.xsl raises an error. Example:

```XML
<?xml version="1.0" encoding="UTF-8"?>
<section xmlns="http://docbook.org/ns/docbook" xmlns:xinfo="http://ns.expertinfo.se/cms/xmlns/1.0"
    xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1">
    <title>Section title</title>
    <para>Paragraph</para>
    <informaltable condition="hidden" xinfo:product="Product1;Product2">
        <thead>
            <tr>
                <th>Head</th>
            </tr>
        </thead>
        <tbody>
            <tr>
                <td>Cell</td>
            </tr>
        </tbody>
    </informaltable>
</section>
```