### PR TITLE
Issue #579 removes unnecessary down-up fragments in URIs

### DIFF
--- a/src/main/xslt/standalone-functions.xsl
+++ b/src/main/xslt/standalone-functions.xsl
@@ -36,6 +36,30 @@
                        'annotation-collection')"/>
   
 <!-- ====================================================================================
+|    Functions for general use
+|==================================================================================   -->  
+  
+<!-- Remove down-up fragments in $uri: /a/b/c/../../d becomes /a/d  -->  
+<xsl:function name="fp:shorten-uri" as="xs:anyURI">
+  <xsl:param name="uri" as="xs:anyURI"/>
+    <xsl:variable name="result" as="xs:string*" >
+      <xsl:analyze-string select="$uri" regex="/[^/]+/\.\."> 
+        <xsl:non-matching-substring>
+          <xsl:sequence select="."/>
+        </xsl:non-matching-substring>
+      </xsl:analyze-string>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="string-join($result) eq $uri">
+        <xsl:sequence select="xs:anyURI($uri)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="string-join($result) => xs:anyURI() => fp:shorten-uri()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+</xsl:function>  
+  
+<!-- ====================================================================================
 |    Functions for processing instructions and their pseudo attributes
 |===================================================================================  -->  
 


### PR DESCRIPTION
Adds a new function in `standalone-functions.xsl` (since there are no dependencies to the framework) to shorten an `xs:anyURI` by removing down-up steps like `fo/..`. Using this function for `$vp:chunk-output-base-uri`.

Should resolve Issue 579