### PR TITLE
Allow secondary documents in transforms. Add ghost:sourcefile attribute to img elements

### DIFF
--- a/src/main/xslt/docbook-paged.xsl
+++ b/src/main/xslt/docbook-paged.xsl
@@ -120,7 +120,10 @@
       <xsl:apply-templates select="*/h:header" mode="m:chunk-cleanup"/>
       <main>
         <xsl:apply-templates select="*/* except */h:header"
-                             mode="m:chunk-cleanup"/>
+                             mode="m:chunk-cleanup">
+          <xsl:with-param name="rootbaseuri" select="$rbu" tunnel="yes"/>
+          <xsl:with-param name="chunkbaseuri" select="$cbu" tunnel="yes"/>
+        </xsl:apply-templates>
       </main>
     </body>
   </html>

--- a/src/main/xslt/modules/objects.xsl
+++ b/src/main/xslt/modules/objects.xsl
@@ -5,6 +5,7 @@
                 xmlns:ext="http://docbook.org/extensions/xslt"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
+                xmlns:ghost="http://docbook.org/ns/docbook/ephemeral"
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
                 xmlns:map="http://www.w3.org/2005/xpath-functions/map"
@@ -757,6 +758,7 @@
     </xsl:when>
     <xsl:otherwise>
       <xsl:call-template name="t:mediaobject-img">
+        <xsl:with-param name="sourcefile" select="$info?uri"/>
         <xsl:with-param name="filename" select="$info?href"/>
         <xsl:with-param name="styles" select="$styles"/>
         <xsl:with-param name="viewport" select="$viewport"/>
@@ -767,12 +769,13 @@
 </xsl:template>
 
 <xsl:template name="t:mediaobject-img">
+  <xsl:param name="sourcefile" as="xs:string"/>
   <xsl:param name="filename" as="xs:string"/>
   <xsl:param name="styles" as="xs:string*"/>
   <xsl:param name="viewport" as="map(*)?"/>
   <xsl:param name="imageproperties" as="map(*)?"/>
 
-  <img src="{$filename}">
+  <img src="{$filename}" ghost:sourcefile="{$sourcefile}">
     <xsl:apply-templates select="." mode="m:attributes"/>
     
     <!-- Apply any alt text in the media object to the image tag. -->


### PR DESCRIPTION
See Issue #598 

Changes the signature of `fp:run-transforms` in _docbook.xsl_ to return a `map(*)` instead of a document node.

The implementation may seem over-complicated. I started with the obvious approach: only one map within the `xsl:iterate` for the principal result and secondary results. Which worked fine for most of the tests, but failed without any error message at `table-cals.049`, which is a huge table. I can only suspect that there is a problem with very large values inside maps in saxon under special circumstances? So i have to use two parameters within `xsl:iterate`: a document-node for the principal document, and a map for secondary result documents. Both are merged into a single map as function result on completion.

I also added a `ghost:sourcefile` to image files. My main motivation for secondary results in pipelines are copy instructions for media files.