### PR TITLE
Remove . and .. path segments from $vp:chunk-output-base-uri

### DIFF
--- a/src/guide/xml/ref-functions.xml
+++ b/src/guide/xml/ref-functions.xml
@@ -2523,4 +2523,24 @@ testing, you can also use the
 </refsection>
 </refentry>
 
+<refentry xml:id="f_flatten-path">
+  <?db filename='f_flatten-path'?>
+  <refmeta>
+    <refentrytitle>f:flatten-path</refentrytitle>
+    <refmiscinfo>{http://docbook.org/ns/docbook/functions}flatten-path#1</refmiscinfo>
+    <refmiscinfo class="version">2.6.0</refmiscinfo>
+  </refmeta>
+  <refnamediv>
+    <refname>f:flatten-path</refname>
+    <refpurpose>Removes “.” and “..” segments from the path of a URI</refpurpose>
+    <refclass>function</refclass>
+  </refnamediv>
+<refsection>
+<title>Description</title>
+<para>This function removes <code>.</code> and <code>..</code> segments from the path portion
+of a (assumed to be hierarchical) URI. It issues a warning (but does not cause the stylesheet
+to fail) if an attempt is made to navigate beyond the root.</para>
+</refsection>
+</refentry>
+
 </reference>

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -159,25 +159,29 @@
      get normalized because later on we're going to want to compare
      the prefix of this base URI with the prefix of another URI. -->
 <xsl:variable name="vp:chunk-output-base-uri" as="xs:anyURI?">
-  <xsl:choose>
-    <xsl:when use-when="function-available('ext:cwd')"
-              test="true()">
-      <xsl:if test="'chunks' = $v:debug">
-        <xsl:message select="'Chunk output base uri:',
-                             resolve-uri($chunk-output-base-uri, ext:cwd())"/>
-      </xsl:if>
-      <xsl:sequence select="resolve-uri($chunk-output-base-uri, ext:cwd())"/>
-    </xsl:when>
-    <xsl:when test="$v:chunk">
-      <xsl:if test="'chunks' = $v:debug">
-        <xsl:message select="'Chunk output base uri:', $chunk-output-base-uri"/>
-      </xsl:if>
-      <xsl:sequence select="xs:anyURI($chunk-output-base-uri)"/>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:sequence select="xs:anyURI($chunk-output-base-uri)"/>
-    </xsl:otherwise>
-  </xsl:choose>
+  <xsl:variable name="result" as="xs:anyURI">
+    <xsl:choose>
+      <xsl:when test="not($chunk-output-base-uri) castable as xs:anyURI">
+        <xsl:message
+            select="'Error: ' || $chunk-output-base-uri || ' is not valid as $chunk-output-base-uri.'"/>
+      </xsl:when>
+      <xsl:when use-when="function-available('ext:cwd')" test="true()">
+        <xsl:sequence select="resolve-uri($chunk-output-base-uri, ext:cwd())"/>
+      </xsl:when>
+      <xsl:when test="$v:chunk">
+        <xsl:sequence select="xs:anyURI($chunk-output-base-uri)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="xs:anyURI($chunk-output-base-uri)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:if test="'chunks' = $v:debug">
+    <xsl:message select="'Chunk output base uri:', f:flatten-path($result)"/>
+  </xsl:if>
+
+  <xsl:sequence select="f:flatten-path($result)"/>
 </xsl:variable>
 
 <!-- I tinkered a bit to find images that would display across

--- a/src/test/xspec/flatten-path.xspec
+++ b/src/test/xspec/flatten-path.xspec
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<x:description xmlns:db="http://docbook.org/ns/docbook"
+               xmlns:h="http://www.w3.org/1999/xhtml"
+               xmlns:f="http://docbook.org/ns/docbook/functions"
+               xmlns:m="http://docbook.org/ns/docbook/modes"
+               xmlns:x="http://www.jenitennison.com/xslt/xspec"
+               stylesheet="../../../build/xspec-xslt/xspec-driver.xsl">
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'/path/to/thing'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = '/path/to/thing'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'/path/to/./././thing'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = '/path/to/thing'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'c:\path\where\..\to\thing'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = 'c:/path/to/thing'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'file:/c:/path/to/where/../thing'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = 'file:/c:/path/to/thing'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'http://example.com/path/../../warning/message'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = 'http://example.com/warning/message'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'https://example.com/a/././././b/x/../x/../x/../c/.'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = 'https://example.com/a/b/c'"/>
+</x:scenario>
+
+<x:scenario label="When flattening a URI path">
+  <x:call function="f:flatten-path">
+    <x:param name="hierarchical-uri" select="'https://example.com/a/././././b/x/../x/../x/../c/d/..'"/>
+  </x:call>
+  <x:expect label="expect a normalized result"
+            test=". = 'https://example.com/a/b/c'"/>
+</x:scenario>
+
+</x:description>


### PR DESCRIPTION
Fix #579

I wasn’t actually able to reproduce this bug, but the solution seems reasonable, so I implemented it.