### PR TITLE
check if table width exceeds nominal page width more than treshold

### DIFF
--- a/src/main/xslt/standalone-functions.xsl
+++ b/src/main/xslt/standalone-functions.xsl
@@ -378,4 +378,13 @@
   <xsl:sequence select="xs:anyURI($prefix || string-join($result, '/'))"/>
 </xsl:function>
 
+<!-- like standard fn:path, but with DocBook Namespace removed -->
+<xsl:function name="fp:path" as="xs:string?">
+  <xsl:param name="node" as="node()?"/>
+  <xsl:sequence select="
+      let $db := 'Q\{http://docbook\.org/ns/docbook\}'
+      return
+        path($node) ! replace(., $db, '')"/>
+</xsl:function>
+
 </xsl:stylesheet>


### PR DESCRIPTION
See #609. Switch to relative width occurs only if sum of column widths exceeds `$nominal-page-width` by more than a `$treshold`, which is `1px`. This helps to avoid false positive test because of rounding errors.

Analysis shows a potential issue with `f:absolute-length` in module `units.xsl`: although the value is rounded without fraction digits, the function signature gives it the type `xs:double`. I think function signature should be changed to

```
<xsl:function name="f:absolute-length" as="xs:nonNegativeInteger">
```

If table width really exceeds `nominal-page-width`, the error message is optimized and informs about the amount of exceeding as well as the path of the table in question.