### PR TITLE
Fix error in computed scope for generating an index

### DIFF
--- a/src/main/xslt/modules/index.xsl
+++ b/src/main/xslt/modules/index.xsl
@@ -169,7 +169,7 @@
 <!-- ============================================================ -->
 
 <xsl:template name="t:generate-index">
-  <xsl:param name="scope" select="(ancestor::db:book|/)[last()]"/>
+  <xsl:param name="scope" select="(ancestor::db:book|/*)[last()]"/>
 
   <xsl:variable name="role"
                 select="if (f:is-true($index-on-role))


### PR DESCRIPTION
The default scope is the nearest ancestor book, or, if there isn’t an ancestor book, the root of the document.

Fix #620 