### PR TITLE
Support language localization with Saxon PE

### DIFF
--- a/src/main/xslt/modules/inlines.xsl
+++ b/src/main/xslt/modules/inlines.xsl
@@ -179,19 +179,14 @@
     <xsl:when test="string(.) castable as xs:dateTime">
       <xsl:call-template name="t:inline">
         <xsl:with-param name="content" as="xs:string">
-          <!-- Don't attempt to use localization on Saxon HE -->
+          <!-- Don't attempt to use language localization on Saxon HE -->
           <xsl:sequence
               use-when="system-property('xsl:product-name') = 'SAXON'
-                        and not(
-                           starts-with(system-property('xsl:product-version'), 'EE')
-                           )"
+                        and starts-with(system-property('xsl:product-version'), 'HE')"
               select="format-dateTime(xs:dateTime(.), $format)"/>
-
           <xsl:sequence
               use-when="not(system-property('xsl:product-name') = 'SAXON'
-                            and not(
-                              starts-with(system-property('xsl:product-version'), 'EE')
-                              ))"
+                            and starts-with(system-property('xsl:product-version'), 'HE'))"
               select="format-dateTime(xs:dateTime(.), $format,
                                       f:l10n-language(.), (), ())"/>
         </xsl:with-param>
@@ -203,18 +198,14 @@
     <xsl:when test="string(.) castable as xs:date">
       <xsl:call-template name="t:inline">
         <xsl:with-param name="content" as="xs:string">
-          <!-- Don't attempt to use localization on Saxon HE -->
+          <!-- Don't attempt to use language localization on Saxon HE -->
           <xsl:sequence
               use-when="system-property('xsl:product-name') = 'SAXON'
-                        and not(
-                           starts-with(system-property('xsl:product-version'), 'EE')
-                           )"
+                        and starts-with(system-property('xsl:product-version'), 'HE')"
               select="format-date(xs:date(.), $format)"/>
           <xsl:sequence
               use-when="not(system-property('xsl:product-name') = 'SAXON'
-                            and not(
-                              starts-with(system-property('xsl:product-version'), 'EE')
-                              ))"
+                            and starts-with(system-property('xsl:product-version'), 'HE'))"
               select="format-date(xs:date(.), $format,
                                   f:l10n-language(.), (), ())"/>
         </xsl:with-param>


### PR DESCRIPTION
Fix #647

Attempting to generate day or month names in a language other than English doesn’t work with Saxon HE. But it does work with Saxon PE which was not supported by the stylesheets.

Note that HE doesn’t fail, it outputs [language: en] to alert you that it ignored the language. For some reason, I decided to work around this by avoiding the language localization when using Saxon HE. I’m not sure that was the right thing to do, but it’s been that way for a long time and it doesn’t seem worth breaking backwards compatibility over.

Note that it is possible to add localization support to Saxon HE. If you did that, you’d want a switch to disable the default behavior here. I’m not adding that until someone asks because I think it’s pretty unlikely.