### PR TITLE
DocBook xslTNG Stylesheets version 2.7.0

### DIFF
--- a/properties.gradle
+++ b/properties.gradle
@@ -2,8 +2,8 @@
 ext {
   xslTNGtitle = 'DocBook xslTNG'
   xslTNGbaseName = 'docbook-xslTNG'
-  xslTNGversion = '2.6.1'
-  guideVersion = '2.6.1'
+  xslTNGversion = '2.7.0'
+  guideVersion = '2.7.0'
   guidePrerelease = false
 
   docbookVersion = '5.2'

--- a/src/guide/xml/changelog.xml
+++ b/src/guide/xml/changelog.xml
@@ -10,6 +10,58 @@ be of interest to users of the stylesheets. See the commits and pull requests on
 <link xlink:href="https://github.com/docbook/xslTNG/">the repository</link> for
 finer detail.</para>
 
+<section xml:id="r270">
+<info>
+  <title>Changes in version 2.7.0</title>
+  <productnumber>2.7.0</productnumber>
+  <date>2025-11-09</date>
+</info>
+
+<important>
+<para>This release contains <emphasis>backwards incompatible</emphasis> changes in
+the way relative media object widths are computed. If you specify media object
+widths or depths with percentages, take special care to assure you’re getting the
+results you expect. Use <parameter>mediaobject-percentage-of-intrinsic-size</parameter>
+to select backwards compatible behavior.</para>
+</important>
+ 
+<itemizedlist>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/657">#657</link>.
+If a resource path appears to be absolute, don’t add the resource base URI to it.
+</para></listitem>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/655">#655</link>.
+Avoid duplicate ID values in automatically generated glossaries when
+a document consists of multiple books.
+</para></listitem>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/654">#654</link>.
+Corrected the context for abstracts in titlepage templates.
+</para></listitem>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/651">#651</link>.
+Avoid a runtime error when using multiple admonition icons.
+</para></listitem>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/648">#648</link>.
+When the width or depth of a media object is specified as a percentage, it is
+supposed to be a percentage of the available space. All versions of the
+stylesheets before 2.7.0 incorrectly calculate percentages against the intrinsic
+size of the media object. That has been fixed. Note that this is a backwards
+incompatible change if you specify widths or depths as percentages.
+Use <parameter>mediaobject-percentage-of-intrinsic-size</parameter>
+to select backwards compatible behavior.
+</para></listitem>
+<listitem><para>Fixed <link xlink:href="https://github.com/docbook/xslTNG/issues/651">#647</link>.
+Support language localization with Saxon PE.
+</para></listitem>
+<listitem><para>Improved the fix for <link xlink:href="https://github.com/docbook/xslTNG/issues/581">#581</link>.
+It occurred to me that the templates processing CALS tables do know the width
+of each column. That allows the available space in a CALS table to be computed
+correctly for media objects that specify widths as a percentage. This is also
+a backwards incompatible change. Like the fix for #648, backwards compatible
+behavior can be retained with the
+<parameter>mediaobject-percentage-of-intrinsic-size</parameter> parameter.
+</para></listitem>
+</itemizedlist>
+</section>
+
 <section xml:id="r261">
 <info>
   <title>Changes in version 2.6.1</title>

--- a/src/guide/xml/guide.xml
+++ b/src/guide/xml/guide.xml
@@ -14,7 +14,7 @@
 <pubdate/>
 <legalnotice>
 <literallayout><citetitle>DocBook xslTNG</citetitle>
-Copyright © 2020–2024 Norman Walsh.
+Copyright © 2020–2025 Norman Walsh.
 All Rights Reserved.</literallayout>
 
 <para>Permission is granted to copy, distribute and/or modify this
@@ -43,6 +43,7 @@ contained herein.</para>
 <year>2022</year>
 <year>2023</year>
 <year>2024</year>
+<year>2025</year>
 <holder>Norman Walsh</holder>
 </copyright>
 </info>

--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -2646,7 +2646,15 @@ See <varname>v:mediaobject-output-base-uri</varname>.
   </refnamediv>
 <refsection>
 <title>Description</title>
-<para>FIXME:</para>
+<para>If <parameter>mediaobject-output-paths</parameter> <glossterm>is true</glossterm>,
+media object locations are assumed to be correct, relative to the resource base URI.
+For example, if the <tag class="attribute">fileref</tag> is <literal>path/to/image.svg</literal>,
+that relative path will be preserved as the relative location against the resource base URI
+in the output.</para>
+<para>If this parameter is false, then the path component of media objects is discarded.
+All media objects are assumed to be in the location identified by the resource base URI.
+In other words, <literal>path/to/image.svg</literal> will be treated as if it was simply
+<literal>image.svg</literal>.</para>
 </refsection>
 </refentry>
 
@@ -6095,6 +6103,9 @@ actual width that will be available when the document is formatted. Most often, 
 results in a calculation against the <parameter>image-nominal-height</parameter> and
 <parameter>image-nominal-width</parameter>.</para>
 </note>
+
+<para>Available widths can sometimes be calculated, for example in CALS tables, but
+depth percentages are always resolved against the nominal height.</para> 
 
 </refsection>
 </refentry>  


### PR DESCRIPTION
This is a backwards incompatible release.

Bump version numbers, update changelog, fix a few documentation issues.