### PR TITLE
new parameter callout-number-from for numeration of callouts

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -548,6 +548,64 @@ the list, the one just before the first character.</para>
 be 9312, U2460, “①”.</para>
 </refsection>
 </refentry>
+  
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string</type>
+      <varname>callout-number-from</varname>
+      <initializer>'verbatims sections'</initializer>
+    </fieldsynopsis>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>Controls numeration of callouts</refpurpose>
+  </refnamediv>
+  <refsection>
+    <title>Description</title>
+    <para>Numeration of <tag>co</tag> elements starts from the most recent node in any of the
+      following categories:</para>
+    <variablelist>
+      <varlistentry>
+        <term>books</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>components</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>sections</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>verbatims</term>
+        <listitem>
+          <para>Despite its name, this category incudes not only <literal>computeroutput</literal>,
+                <literal>literallayout</literal>, <literal>programlisting</literal>,
+                <literal>screen</literal>, <literal>imageobjectco</literal>,
+                <literal>programlistingco</literal> and <literal>screenco</literal>, but also
+                <literal>classsynopsis</literal>, <literal>cmdsynopsis</literal>,
+                <literal>constructorsynopsis</literal>, <literal>destructorsynopsis</literal>,
+                <literal>enumsynopsis</literal>, <literal>fieldsynopsis</literal>,
+                <literal>funcsynopsis</literal>, <literal>macrosynopsis</literal>,
+                <literal>methodsynopsis</literal>, <literal>packagesynopsis</literal>,
+                <literal>typedefsynopsis</literal>, <literal>unionsynopsis</literal> and
+                <literal>synopsis</literal>.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    <para>With the default value, callout numbers will be counted separately for every verbatim or
+        synopsis element, if any (with section s as fallback). If you don't want a reset for
+        callouts numeration in the whole book, set this parameter to
+        <literal>books</literal>.</para>
+  </refsection>
+</refentry>  
 
 <refentry>
   <refmeta>
@@ -5321,7 +5379,7 @@ always numbered sequentially within their parent section.</para>
 </variablelist>
 </refsection>
 </refentry>
-
+  
 <refentry>
   <refmeta>
     <fieldsynopsis>

--- a/src/main/xslt/modules/functions.xsl
+++ b/src/main/xslt/modules/functions.xsl
@@ -860,4 +860,26 @@
   </xsl:choose>
 </xsl:function>
   
+<xsl:function name="fp:count-co-number-from" as="element()">
+  <!-- the nearest ancestor of $co where numbering of callouts (re)starts -->
+  <xsl:param name="co" as="element(db:co)"/>
+  <xsl:variable name="synopsis" as="xs:string+" select="
+      ('classsynopsis', 'cmdsynopsis', 'constructorsynopsis', 'destructorsynopsis',
+      'enumsynopsis', 'fieldsynopsis', 'funcsynopsis', 'macrosynopsis',
+      'methodsynopsis', 'packagesynopsis', 'synopsis', 'typedefsynopsis', 'unionsynopsis')"/>
+  <xsl:variable name="verbatim" as="xs:string+" select="
+      ('computeroutput', 'literallayout', 'programlisting', 'screen',
+      'imageobjectco', 'programlistingco', 'screenco')"/>
+  <xsl:variable name="block" as="xs:string+" select="
+      ('section', 'sect1', 'sect2', 'sect3',
+      'sect4', 'sect5', 'refentry','preface','chapter','appendix')"/>
+  <xsl:variable name="tags" as="xs:string+" select="($synopsis, $verbatim, $block)"/>
+  <xsl:variable name="from" as="element()?" select="($co/ancestor::*[local-name() = $tags])[last()]"/>
+  <xsl:choose>
+    <xsl:when test="exists($from)">
+      <xsl:message select="'Count from ' || local-name($from)"></xsl:message>
+    </xsl:when>
+  </xsl:choose>
+  <xsl:sequence select="($from,root($co))[1]"/>
+</xsl:function>  
 </xsl:stylesheet>

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -7,6 +7,7 @@
                 xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:ls="http://docbook.org/ns/docbook/l10n/source"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
                 xmlns:v="http://docbook.org/ns/docbook/variables"
                 xmlns:vp="http://docbook.org/ns/docbook/variables/private"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -37,6 +38,38 @@
 
 <xsl:variable name="v:chunk" as="xs:boolean"
               select="not(normalize-space($chunk) = '')"/>
+  
+<xsl:variable name="vp:callout-number-from" as="xs:string*">
+  <!-- Analyze parameter $callout-number-from and return the element names
+       that belong to the element categories -->
+  <xsl:variable name="categories" as="map(*)" select="
+      map {
+        'books': ('book'),
+        'components': ('acknowledgements', 'appendix', 'article',
+        'bibliography', 'chapter', 'colophon', 'dedication',
+        'glossary', 'partintro', 'preface', 'refentry'),
+        'sections': ('section', 'sect1', 'sect2', 'sect3', 'sect4',
+        'sect5', 'simplesect'),
+        'verbatims': ('computeroutput', 'literallayout', 'programlisting', 'screen',
+        'imageobjectco', 'programlistingco', 'screenco', 'classsynopsis', 'cmdsynopsis', 'constructorsynopsis', 'destructorsynopsis',
+        'enumsynopsis', 'fieldsynopsis', 'funcsynopsis', 'macrosynopsis',
+        'methodsynopsis', 'packagesynopsis', 'synopsis', 'typedefsynopsis', 'unionsynopsis')
+      }"/>
+  
+  <xsl:iterate select="map:keys($categories)">
+    <xsl:param name="patterns" as="xs:string*" select="()"/>
+    <xsl:on-completion>
+      <xsl:sequence select="$patterns" />
+    </xsl:on-completion>
+    <xsl:next-iteration>
+      <xsl:with-param name="patterns" select="
+        if (. = tokenize($callout-number-from, '\s+')) then
+        ($patterns, $categories(.))
+        else
+        $patterns"/>
+    </xsl:next-iteration>
+  </xsl:iterate>
+</xsl:variable>  
 
 <xsl:variable name="vp:section-toc-depth" as="xs:integer">
   <xsl:choose>

--- a/src/main/xslt/modules/verbatim.xsl
+++ b/src/main/xslt/modules/verbatim.xsl
@@ -1380,9 +1380,14 @@
         <xsl:sequence select="@label"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:number count="db:co"
-                    level="any"
-                    format="1"/>
+          <xsl:variable name="from" as="node()+" select="
+              let $n := ancestor-or-self::*[local-name() = $vp:callout-number-from]
+              return
+                if (exists($n)) then
+                  $n
+                else
+                  root()"/>
+        <xsl:number count="db:co" level="any" from="$from" format="1"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/src/test/resources/expected/calloutlist.003.html
+++ b/src/test/resources/expected/calloutlist.003.html
@@ -26,22 +26,22 @@ also that several items in co/@linkends are correctly handled.
 <span class="line"><span class="ld"><code> Directory of  C:\</code></span></span>
 <span class="line"><span class="ld"><code> </code></span></span>
 <span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    bin</code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:11         &lt;DIR&gt;    DOS <span class="co" id="dos">⑦</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:11         &lt;DIR&gt;    DOS <span class="co" id="dos">①</span></code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:40         &lt;DIR&gt;    Program Files</code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:46         &lt;DIR&gt;    TEMP <span class="coref"><span class="error broken-link"><a href="#unknown"></a></span></span></code></span></span>
-<span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    tmp <span class="co">⑦</span></code></span></span>
+<span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    tmp <span class="co">①</span></code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:37         &lt;DIR&gt;    WINNT</code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:25             119  AUTOEXEC.BAT <span class="co" id="autoexec.bat">⑧</span></code></span></span>
-<span class="line"><span class="ld"><code> 2/13/94   6:21          54,619  COMMAND.COM <span class="co" id="command.com">⑨</span></code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:25             115  CONFIG.SYS <span class="co" id="config.sys">⑩</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:25             119  AUTOEXEC.BAT <span class="co" id="autoexec.bat">②</span></code></span></span>
+<span class="line"><span class="ld"><code> 2/13/94   6:21          54,619  COMMAND.COM <span class="co" id="command.com">③</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:25             115  CONFIG.SYS <span class="co" id="config.sys">④</span></code></span></span>
 <span class="line"><span class="ld"><code>11/16/97  17:17      61,865,984  pagefile.sys</code></span></span>
-<span class="line"><span class="ld"><code> 2/13/94   6:21           9,349  WINA20.386 <span class="co" id="wina20.386">⑪</span></code></span></span></pre></div><div class="calloutlist"><dl><dt id="firstco" class="callout"><a class="callout-bug" href="#dos">⑦</a></dt><dd><p>
+<span class="line"><span class="ld"><code> 2/13/94   6:21           9,349  WINA20.386 <span class="co" id="wina20.386">⑤</span></code></span></span></pre></div><div class="calloutlist"><dl><dt id="firstco" class="callout"><a class="callout-bug" href="#dos">①</a></dt><dd><p>
   This directory holds <span class="trademark">MS-DOS</span>, the
   operating system that was installed before <span class="trademark">Windows
   NT</span>.
-  </p></dd><dt id="startup" class="callout"><a class="callout-bug" href="#autoexec.bat">⑧</a><a class="callout-bug" href="#command.com">⑨</a><a class="callout-bug" href="#config.sys">⑩</a></dt><dd><p>
+  </p></dd><dt id="startup" class="callout"><a class="callout-bug" href="#autoexec.bat">②</a><a class="callout-bug" href="#command.com">③</a><a class="callout-bug" href="#config.sys">④</a></dt><dd><p>
   System startup code for DOS.
-  </p></dd><dt id="lastco" class="callout"><a class="callout-bug" href="#wina20.386">⑪</a></dt><dd><p>
+  </p></dd><dt id="lastco" class="callout"><a class="callout-bug" href="#wina20.386">⑤</a></dt><dd><p>
   Some sort of <span class="trademark">Windows 3.1</span> hack for some 386 processors,
   as I recall.
   </p></dd></dl></div></section><section id="R_s1_s2" class="section"><header><h3><span class="label">1<span class="sep">.</span>2</span><span class="sep">. </span>Programlistingco</h3></header><p>This case checks that spaces are added to reach the expected


### PR DESCRIPTION
See #623 Introduces the new parameter $callout-number-from. Numeration of co elements starts from the most recent node in any of the following categories: books, components, sections and verbatims (which includes synopsis elements).

With the default value, callout numbers will be counted separately for every verbatim or synopsis element, if any (with sections as fallback). This affects test case calloutlist.003.

If you want the current behavior (no reset for callouts numeration at all in the whole book), set this parameter to 'books'.

New global variable $vp:callout-number-from acts like a compiled version of the $callout-number-from parameter.