### PR TITLE
Improve numbering of co elements; change the default

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -6110,4 +6110,62 @@ depth percentages are always resolved against the nominal height.</para>
 </refsection>
 </refentry>  
 
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string</type>
+      <varname>cos-number-from</varname>
+      <initializer>'verbatim section'</initializer>
+      <refmiscinfo class="version">2.7.2</refmiscinfo>
+  </fieldsynopsis>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>Controls numeration of <tag>co</tag> elements</refpurpose>
+  </refnamediv>
+  <refsection>
+    <title>Description</title>
+    <para>Numeration of <tag>co</tag> elements starts from the most recent node in any of the
+      following categories:</para>
+    <variablelist>
+      <varlistentry>
+        <term>books</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>components</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>sections</term>
+        <listitem>
+          <para>See <xref linkend="numeration" xrefstyle="%label"/></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>verbatims</term>
+        <listitem>
+          <para>Despite its name, this category incudes not only <literal>computeroutput</literal>,
+                <literal>literallayout</literal>, <literal>programlisting</literal>,
+                <literal>screen</literal>, <literal>imageobjectco</literal>,
+                <literal>programlistingco</literal> and <literal>screenco</literal>, but also
+                <literal>classsynopsis</literal>, <literal>cmdsynopsis</literal>,
+                <literal>constructorsynopsis</literal>, <literal>destructorsynopsis</literal>,
+                <literal>enumsynopsis</literal>, <literal>fieldsynopsis</literal>,
+                <literal>funcsynopsis</literal>, <literal>macrosynopsis</literal>,
+                <literal>methodsynopsis</literal>, <literal>packagesynopsis</literal>,
+                <literal>typedefsynopsis</literal>, <literal>unionsynopsis</literal> and
+                <literal>synopsis</literal>.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    <para>With the default value, callout numbers will be counted separately for
+    every verbatim or synopsis element, if any (with sections as a fallback). If
+    you don't want a reset for callouts numeration in the whole book, set this
+    parameter to <literal>books</literal>.</para>
+  </refsection>
+</refentry>
 </reference>

--- a/src/main/xslt/modules/numbers.xsl
+++ b/src/main/xslt/modules/numbers.xsl
@@ -774,4 +774,172 @@
   <xsl:number level="single"/>
 </xsl:template>
 
+<!-- ============================================================ -->
+
+<xsl:function name="fp:choose-cos-number-from" as="xs:string">
+  <xsl:param name="co" as="element(db:co)"/>
+
+  <xsl:iterate select="$vp:cos-number-from">
+    <xsl:choose>
+      <xsl:when test=". = 'book' or . = 'set' or position() = last()">
+        <xsl:sequence select="."/>
+        <xsl:break/>
+      </xsl:when>
+      <xsl:when test=". = 'division'
+                      and ($co/ancestor::db:part|$co/ancestor::db:reference)">
+        <xsl:sequence select="."/>
+        <xsl:break/>
+      </xsl:when>
+      <xsl:when test=". = 'component'
+                      and ($co/ancestor::db:preface|$co/ancestor::db:chapter
+                           |$co/ancestor::db:appendix|$co/ancestor::db:partintro
+                           |$co/ancestor::db:dedication|$co/ancestor::db:colophon
+                           |$co/ancestor::db:acknowledgements
+                           |$co/ancestor::db:article|$co/ancestor::db:refentry
+                           |$co/ancestor::db:glossary|$co/ancestor::db:bibliography
+                           |$co/ancestor::db:index|$co/ancestor::db:setindex)">
+        <xsl:sequence select="."/>
+        <xsl:break/>
+      </xsl:when>
+      <xsl:when test=". = 'section'
+                      and ($co/ancestor::db:section|$co/ancestor::db:sect1
+                           |$co/ancestor::db:sect2|$co/ancestor::db:sect3
+                           |$co/ancestor::db:sect4|$co/ancestor::db:sect5)">
+                           |$co/ancestor::db:preface|$co/ancestor::db:chapter
+                           |$co/ancestor::db:appendix|$co/ancestor::db:partintro
+                           |$co/ancestor::db:dedication|$co/ancestor::db:colophon
+                           |$co/ancestor::db:acknowledgements
+                           |$co/ancestor::db:article|$co/ancestor::db:refentry
+                           |$co/ancestor::db:glossary|$co/ancestor::db:bibliography
+                           |$co/ancestor::db:index|$co/ancestor::db:setindex)">
+        <xsl:sequence select="."/>
+        <xsl:break/>
+      </xsl:when>
+      <xsl:when test=". = 'verbatim'
+                      and ($co/ancestor::db:classsynopsis|$co/ancestor::db:cmdsynopsis
+                           |$co/ancestor::db:computeroutput|$co/ancestor::db:constructorsynopsis
+                           |$co/ancestor::db:destructorsynopsis|$co/ancestor::db:enumsynopsis
+                           |$co/ancestor::db:fieldsynopsis|$co/ancestor::db:funcsynopsis
+                           |$co/ancestor::db:imageobjectco|$co/ancestor::db:literallayout
+                           |$co/ancestor::db:macrosynopsis|$co/ancestor::db:methodsynopsis
+                           |$co/ancestor::db:packagesynopsis|$co/ancestor::db:programlistingco
+                           |$co/ancestor::db:programlisting|$co/ancestor::db:screenco
+                           |$co/ancestor::db:screen|$co/ancestor::db:synopsis
+                           |$co/ancestor::db:typedefsynopsis|$co/ancestor::db:unionsynopsis)">
+        <xsl:sequence select="."/>
+        <xsl:break/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-iteration/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:iterate>
+</xsl:function>    
+
+<xsl:template match="db:co" mode="mp:co-number">
+  <xsl:variable name="number-from" select="fp:choose-cos-number-from(.)"/>
+  <xsl:choose>
+    <xsl:when test="$number-from = 'set' and ancestor::db:set">
+      <xsl:number count="db:co" from="db:set" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'set'">
+      <xsl:number count="db:co" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'book' and ancestor::db:book">
+      <xsl:number count="db:co" from="db:book" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'book'">
+      <xsl:number count="db:co" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'division'
+                    and (ancestor::db:part|ancestor::db:reference)">
+      <xsl:number count="db:co"
+                  from="db:part|db:reference" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'division'">
+      <xsl:number count="db:co" from="db:book" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'component'
+                    and (ancestor::db:preface|ancestor::db:chapter
+                         |ancestor::db:appendix|ancestor::db:partintro
+                         |ancestor::db:dedication|ancestor::db:colophon
+                         |ancestor::db:acknowledgements
+                         |ancestor::db:article|ancestor::db:refentry
+                         |ancestor::db:glossary|ancestor::db:bibliography
+                         |ancestor::db:index|ancestor::db:setindex)">
+      <xsl:number count="db:co"
+                  from="db:preface|db:chapter|db:appendix|db:partintro
+                        |db:dedication|db:colophon|db:acknowledgements
+                        |db:article|db:refentry
+                        |db:glossary|db:bibliography
+                        |db:index|db:setindex"
+                  level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'component'">
+      <xsl:number count="db:co" from="db:book" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'section'
+                    and (ancestor::db:section|ancestor::db:sect1
+                         |ancestor::db:sect2|ancestor::db:sect3
+                         |ancestor::db:sect4|ancestor::db:sect5)">
+      <xsl:number count="db:co"
+                  from="db:section|db:sect1|db:sect2|db:sect3|db:sect4|db:sect5"
+                  level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'section'
+                    and (ancestor::db:preface|ancestor::db:chapter
+                         |ancestor::db:appendix|ancestor::db:partintro
+                         |ancestor::db:dedication|ancestor::db:colophon
+                         |ancestor::db:acknowledgements
+                         |ancestor::db:article|ancestor::db:refentry
+                         |ancestor::db:glossary|ancestor::db:bibliography
+                         |ancestor::db:index|ancestor::db:setindex)">
+      <xsl:number count="db:co"
+                  from="db:preface|db:chapter|db:appendix|db:partintro
+                        |db:dedication|db:colophon|db:acknowledgements
+                        |db:article|db:refentry
+                        |db:glossary|db:bibliography
+                        |db:index|db:setindex"
+                  level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'section'">
+      <xsl:number count="db:co" from="db:book" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'verbatim'
+                    and (ancestor::db:classsynopsis|ancestor::db:cmdsynopsis
+                         |ancestor::db:computeroutput|ancestor::db:constructorsynopsis
+                         |ancestor::db:destructorsynopsis|ancestor::db:enumsynopsis
+                         |ancestor::db:fieldsynopsis|ancestor::db:funcsynopsis
+                         |ancestor::db:imageobjectco|ancestor::db:literallayout
+                         |ancestor::db:macrosynopsis|ancestor::db:methodsynopsis
+                         |ancestor::db:packagesynopsis|ancestor::db:programlistingco
+                         |ancestor::db:programlisting|ancestor::db:screenco
+                         |ancestor::db:screen|ancestor::db:synopsis
+                         |ancestor::db:typedefsynopsis|ancestor::db:unionsynopsis)">
+      <xsl:number count="db:co"
+                  from="db:classsynopsis|db:cmdsynopsis
+                        |db:computeroutput|db:constructorsynopsis
+                        |db:destructorsynopsis|db:enumsynopsis
+                        |db:fieldsynopsis|db:funcsynopsis
+                        |db:imageobjectco|db:literallayout
+                        |db:macrosynopsis|db:methodsynopsis
+                        |db:packagesynopsis|db:programlistingco
+                        |db:programlisting|db:screenco
+                        |db:screen|db:synopsis
+                        |db:typedefsynopsis|db:unionsynopsis"
+                  level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'verbatim'">
+      <xsl:number count="db:co" from="db:book" level="any"/>
+    </xsl:when>
+    <xsl:when test="$number-from = 'root'">
+      <xsl:number count="db:co" level="any"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:message select="'Error: cos-number-from='||$cos-number-from"/>
+      <xsl:sequence select="0"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/src/main/xslt/modules/variable.xsl
+++ b/src/main/xslt/modules/variable.xsl
@@ -148,6 +148,9 @@
 <xsl:variable name="vp:user-css-links"
               select="tokenize(normalize-space($user-css-links), '\s+')"/>
 
+<xsl:variable name="vp:cos-number-from"
+              select="tokenize(normalize-space($cos-number-from), '\s+')"/>
+
 <xsl:variable name="v:chunk-renumber-footnotes" as="xs:boolean"
               select="f:is-true($chunk-renumber-footnotes)"/>
 

--- a/src/main/xslt/modules/verbatim.xsl
+++ b/src/main/xslt/modules/verbatim.xsl
@@ -1380,9 +1380,7 @@
         <xsl:sequence select="@label"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:number count="db:co"
-                    level="any"
-                    format="1"/>
+        <xsl:apply-templates select="." mode="mp:co-number"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/src/test/resources/expected/calloutlist.003.html
+++ b/src/test/resources/expected/calloutlist.003.html
@@ -26,22 +26,22 @@ also that several items in co/@linkends are correctly handled.
 <span class="line"><span class="ld"><code> Directory of  C:\</code></span></span>
 <span class="line"><span class="ld"><code> </code></span></span>
 <span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    bin</code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:11         &lt;DIR&gt;    DOS <span class="co" id="dos">⑦</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:11         &lt;DIR&gt;    DOS <span class="co" id="dos">①</span></code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:40         &lt;DIR&gt;    Program Files</code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:46         &lt;DIR&gt;    TEMP <span class="coref"><span class="error broken-link"><a href="#unknown"></a></span></span></code></span></span>
-<span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    tmp <span class="co">⑦</span></code></span></span>
+<span class="line"><span class="ld"><code>10/17/97   9:04         &lt;DIR&gt;    tmp <span class="co">①</span></code></span></span>
 <span class="line"><span class="ld"><code>10/16/97  14:37         &lt;DIR&gt;    WINNT</code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:25             119  AUTOEXEC.BAT <span class="co" id="autoexec.bat">⑧</span></code></span></span>
-<span class="line"><span class="ld"><code> 2/13/94   6:21          54,619  COMMAND.COM <span class="co" id="command.com">⑨</span></code></span></span>
-<span class="line"><span class="ld"><code>10/16/97  14:25             115  CONFIG.SYS <span class="co" id="config.sys">⑩</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:25             119  AUTOEXEC.BAT <span class="co" id="autoexec.bat">②</span></code></span></span>
+<span class="line"><span class="ld"><code> 2/13/94   6:21          54,619  COMMAND.COM <span class="co" id="command.com">③</span></code></span></span>
+<span class="line"><span class="ld"><code>10/16/97  14:25             115  CONFIG.SYS <span class="co" id="config.sys">④</span></code></span></span>
 <span class="line"><span class="ld"><code>11/16/97  17:17      61,865,984  pagefile.sys</code></span></span>
-<span class="line"><span class="ld"><code> 2/13/94   6:21           9,349  WINA20.386 <span class="co" id="wina20.386">⑪</span></code></span></span></pre></div><div class="calloutlist"><dl><dt id="firstco" class="callout"><a class="callout-bug" href="#dos">⑦</a></dt><dd><p>
+<span class="line"><span class="ld"><code> 2/13/94   6:21           9,349  WINA20.386 <span class="co" id="wina20.386">⑤</span></code></span></span></pre></div><div class="calloutlist"><dl><dt id="firstco" class="callout"><a class="callout-bug" href="#dos">①</a></dt><dd><p>
   This directory holds <span class="trademark">MS-DOS</span>, the
   operating system that was installed before <span class="trademark">Windows
   NT</span>.
-  </p></dd><dt id="startup" class="callout"><a class="callout-bug" href="#autoexec.bat">⑧</a><a class="callout-bug" href="#command.com">⑨</a><a class="callout-bug" href="#config.sys">⑩</a></dt><dd><p>
+  </p></dd><dt id="startup" class="callout"><a class="callout-bug" href="#autoexec.bat">②</a><a class="callout-bug" href="#command.com">③</a><a class="callout-bug" href="#config.sys">④</a></dt><dd><p>
   System startup code for DOS.
-  </p></dd><dt id="lastco" class="callout"><a class="callout-bug" href="#wina20.386">⑪</a></dt><dd><p>
+  </p></dd><dt id="lastco" class="callout"><a class="callout-bug" href="#wina20.386">⑤</a></dt><dd><p>
   Some sort of <span class="trademark">Windows 3.1</span> hack for some 386 processors,
   as I recall.
   </p></dd></dl></div></section><section id="R_s1_s2" class="section"><header><h3><span class="label">1<span class="sep">.</span>2</span><span class="sep">. </span>Programlistingco</h3></header><p>This case checks that spaces are added to reach the expected


### PR DESCRIPTION
Fix #623

It’s now possible to renumber callouts (`co` callouts) starting at each verbatim environment or at any of the other places used for numeration boundaries.