### PR TITLE
Added the $label-wrapper parameter for labels

### DIFF
--- a/src/guide/xml/ref-params.xml
+++ b/src/guide/xml/ref-params.xml
@@ -6168,4 +6168,46 @@ depth percentages are always resolved against the nominal height.</para>
     parameter to <literal>books</literal>.</para>
   </refsection>
 </refentry>
+
+<refentry>
+  <refmeta>
+    <fieldsynopsis>
+      <type>xs:string?</type>
+      <varname>label-wrapper</varname>
+      <initializer>()</initializer>
+    </fieldsynopsis>
+    <refmiscinfo class="version">2.7.2</refmiscinfo>
+  </refmeta>
+  <refnamediv>
+    <refpurpose>Additional wrapper around label and separator</refpurpose>
+  </refnamediv>
+<refsection>
+<title>Description</title>
+
+<para>By default, when the stylesheets output a title for a labeled
+element (chapter, section, table, etc.), the label is wrapped in a
+<tag namespace="http://www.w3.org/1999/xhtml">span</tag> with the class “<literal>label</literal>”
+and the separator (if there is one) between the label and the content is wrapped in a
+<tag namespace="http://www.w3.org/1999/xhtml">span</tag> with the class “<literal>sep</literal>”.
+For example:</para>
+
+<programlisting language="xml"
+><![CDATA[<h3><span class="label">3</span><span class="sep">. </span>Section Title</h3>]]></programlisting>
+
+<para>If <parameter>label-wrapper</parameter> is non-empty, then the label <emphasis>and</emphasis>
+the separator are further wrapped in a 
+<tag namespace="http://www.w3.org/1999/xhtml">span</tag> with a class that contains
+the string value of <parameter>label-wrapper</parameter>. For example, if
+<parameter>label-wrapper</parameter> is “<literal>lwrap</literal>”:</para>
+
+<programlisting language="xml"
+><![CDATA[<h3><span class="lwrap">
+  <span class="label">3</span><span class="sep">. </span>
+</span>Section Title</h3>]]></programlisting>
+
+<para>This allows you to group all of the parts together for CSS styling.</para>
+
+</refsection>
+</refentry>
+
 </reference>

--- a/src/main/xslt/modules/titles.xsl
+++ b/src/main/xslt/modules/titles.xsl
@@ -4,6 +4,7 @@
                 xmlns:dbe="http://docbook.org/ns/docbook/errors"
                 xmlns:f="http://docbook.org/ns/docbook/functions"
                 xmlns:fp="http://docbook.org/ns/docbook/functions/private"
+                xmlns:h="http://www.w3.org/1999/xhtml"
                 xmlns:l="http://docbook.org/ns/docbook/l10n"
                 xmlns:lt="http://docbook.org/ns/docbook/l10n/templates"
                 xmlns:m="http://docbook.org/ns/docbook/modes"
@@ -219,11 +220,48 @@
     </script>
   </xsl:if>
 
-  <xsl:apply-templates select="$template" mode="mp:localization">
-    <xsl:with-param name="context" select="."/>
-    <xsl:with-param name="label" select="$label"/>
-    <xsl:with-param name="content" select="$title"/>
-  </xsl:apply-templates>
+  <xsl:choose>
+    <xsl:when test="empty($label-wrapper)">
+      <xsl:apply-templates select="$template" mode="mp:localization">
+        <xsl:with-param name="context" select="."/>
+        <xsl:with-param name="label" select="$label"/>
+        <xsl:with-param name="content" select="$title"/>
+      </xsl:apply-templates>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:variable name="headline" as="node()*">
+        <xsl:apply-templates select="$template" mode="mp:localization">
+          <xsl:with-param name="context" select="."/>
+          <xsl:with-param name="label" select="$label"/>
+          <xsl:with-param name="content" select="$title"/>
+        </xsl:apply-templates>
+      </xsl:variable>
+
+      <xsl:variable name="label" select="$headline/self::h:span[contains-token(@class, 'label')]"/>
+      <xsl:variable name="sep" select="$headline/self::h:span[contains-token(@class, 'sep')]"/>
+
+      <xsl:choose>
+        <xsl:when test="empty($label) or empty($sep)">
+          <xsl:sequence select="$headline"/>
+        </xsl:when>
+        <xsl:when test="count($label) != 1 or count($sep) != 1">
+          <xsl:sequence select="$headline"/>
+        </xsl:when>
+        <xsl:when test="$label &lt;&lt; $sep">
+          <span class="{$label-wrapper}">
+            <xsl:sequence select="$headline[. is $sep or . &lt;&lt; $sep]"/>
+          </span>
+          <xsl:sequence select="$headline[. &gt;&gt; $sep]"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:sequence select="$headline[. &lt;&lt; $sep]"/>
+          <span class="${label-wrapper}">
+            <xsl:sequence select="$headline[. is $sep or . &gt;&gt; $sep]"/>
+          </span>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
This adds a wrapper around both the label and separator for labeled elements. This makes some kinds of CSS styling easier (for example, floating section numbers in the left margin). The default value is the empty sequence for backwards compatibility.

Fix #670